### PR TITLE
Setup + config, self-healing prerequisites, HTML deliverables, English translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ desktop.ini
 .DS_Store
 .vs/
 .idea/
+
+# Pester / test artifacts
+testResults*.xml

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ psadt-deploy/
 ├─ README.md  ·  LICENSE
 ├─ scripts/                          Get/Set-PsadtConfig, Get-PsadtModule, Get-IntuneWinAppUtil
 │                                    (upload scripts arrive with the future upload feature)
-├─ references/                       PSADTv4-Deployment-Guide.md, app-registration.md
+├─ references/                       PSADTv4-Deployment-Guide.md
+│                                    (app-registration.md arrives with the upload feature)
 ├─ docs/superpowers/specs/           design documents
 ├─ tools/        (gitignored)        auto-downloaded IntuneWinAppUtil.exe
 ├─ config.json   (gitignored)        machine-local settings

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ description until a task makes it relevant, then the full body loads on demand.
   start, so Company-Portal uninstalls actually work.
 - **Pre-flight checks** — encoding/BOM, AST parse, launcher acid-test per deployment type, and a v3
   cmdlet scan before anything is packaged.
-- **First-run setup** *(in progress)* — a one-time wizard persists machine config (paths, language,
-  author) so conventions are configured once, in one place.
-- **Self-healing prerequisites** *(in progress)* — auto-installs the PSAppDeployToolkit module from the
-  PowerShell Gallery if missing, and auto-downloads `IntuneWinAppUtil.exe`, keeping both current against
-  their official sources. No manual provisioning, no roadblocks.
+- **First-run setup** — a one-time wizard persists machine config (paths, language, author) so
+  conventions are configured once, in one place.
+- **Self-healing prerequisites** — auto-installs the PSAppDeployToolkit module from the PowerShell
+  Gallery if missing, and auto-downloads `IntuneWinAppUtil.exe`, keeping both current against their
+  official sources. No manual provisioning, no roadblocks.
 - **Optional direct Intune upload** *(planned — future release)* — will upload the `.intunewin` via
   Microsoft Graph with an app registration (client secret stored DPAPI-encrypted), and stay fully
   optional with a fallback to the manual dossier flow. **Not in the current version yet** — today you
@@ -113,8 +113,9 @@ psadt-deploy/
 
 ## Status
 
-The core build/package/test/dossier workflow is in active use. **Shipping next:** first-run setup +
-config, self-healing prerequisites (PSADT module + content-prep tool), and HTML deliverables — see the
+The core build/package/test/dossier workflow is in active use. **Shipped:** first-run setup + config,
+self-healing prerequisites (PSADT module + content-prep tool), and HTML deliverables — verified via the
+Pester suite in `tests/`. See the
 [design spec](docs/superpowers/specs/2026-06-04-psadt-skill-setup-design.md) and
 [implementation plan](docs/superpowers/plans/2026-06-04-psadt-skill-setup.md).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,238 +5,238 @@ description: Use this skill when the user wants to build, package, test, trouble
 
 # PSADT v4.x Deployment Skill
 
-## Kurzbeschreibung
+## Summary
 
-Diese Skill begleitet den kompletten Lebenszyklus eines **PSADT-v4.x-Intune-Win32-Pakets** - vom ersten Gespraech bis zum getesteten, hochladefertigen `.intunewin`. Sie ist fuer **Build, Packaging, Test, Troubleshooting und Deployment** gedacht (Trigger u.a. "PSADT Paket bauen", "Intune Paket fuer <App>", "PSADT v4 deploy", oder Arbeit in einem Ordner mit `Invoke-AppDeployToolkit.ps1`).
+This skill guides the complete lifecycle of a **PSADT v4.x Intune Win32 package** - from the first conversation to a tested, upload-ready `.intunewin`. It is intended for **build, packaging, test, troubleshooting, and deployment** (triggers include "PSADT paket bauen", "intune paket fuer <App>", "PSADT v4 deploy", or working in a folder that contains `Invoke-AppDeployToolkit.ps1`).
 
-**Ablauf (9 Phasen):** 1) Intake (8 Kill-Fragen, IMMER per Klick-Optionen) - 2) Web-Recherche (PSADT-Version + Command-Aenderungen, Silent/Uninstall/Repair der App, Intune-Stolpersteine) - 3) Scaffold (`New-ADTTemplate`) - 4) Customizing aller drei Deployment-Types (Install/Uninstall/Repair) - 5) Pre-Flight (Encoding/Parse/Acid-Test) - 6) Packen (IntuneWinAppUtil) - 7) Dossier + Logo - 8) Test - 9) Rollout.
+**Workflow (9 phases):** 1) Intake (8 kill questions, ALWAYS via click options) - 2) Web research (PSADT version + command changes, silent/uninstall/repair of the app, Intune pitfalls) - 3) Scaffold (`New-ADTTemplate`) - 4) Customizing all three deployment types (Install/Uninstall/Repair) - 5) Pre-flight (encoding/parse/acid test) - 6) Packaging (IntuneWinAppUtil) - 7) Dossier + logo - 8) Test - 9) Rollout.
 
-**Verbindliche Konventionen (Details im Block unten):**
-- Fragen an den User IMMER per `AskUserQuestion` (Klick-Optionen), nie als Fliesstext
-- Output-`.intunewin` IMMER zentral nach `paths.outputRoot`/<App>\ (Default `c:\Temp\PSADTv4\Output\`; tatsaechlicher Wert aus der Config via `Get-PsadtConfig`)
-- Intune-Dossier IMMER `Intune-Dossier.html` (komplett HTML), Sprache aus `language.dossier` (**Default Deutsch mit echten Umlauten**); Scripts dagegen **Englisch/ASCII**
-- Author IMMER aus Config zusammengesetzt (`author.person` + `author.company`; Default `Patrick Taubert, PHAT Consulting GmbH`); erste Script-Version `0.1`; Changelog im `.NOTES`-Header Pflicht
-- App-Logo (PNG, transparent, hochaufloesend) besorgen -> `Assets\` + `Output\<App>\`
-- Nur Startmenue-Eintraege, KEINE Desktop-Icons
-- Alle drei Deployment-Types (Install/Uninstall/Repair) von Anfang an mitbauen und per Acid-Test pruefen
+**Binding conventions (details in the block below):**
+- ALWAYS ask the user via `AskUserQuestion` (click options), never as free text
+- Output `.intunewin` ALWAYS centrally to `paths.outputRoot`/<App>\ (default `c:\Temp\PSADTv4\Output\`; actual value from the config via `Get-PsadtConfig`)
+- Intune dossier ALWAYS `Intune-Dossier.html` (full HTML), language from `language.dossier` (**default German with real umlauts**); scripts on the other hand **English/ASCII**
+- Author ALWAYS assembled from config (`author.person` + `author.company`; default `Patrick Taubert, PHAT Consulting GmbH`); first script version `0.1`; changelog in the `.NOTES` header is mandatory
+- Obtain app logo (PNG, transparent, high resolution) -> `Assets\` + `Output\<App>\`
+- Start Menu entries only, NO desktop icons
+- Build all three deployment types (Install/Uninstall/Repair) from the start and verify them via acid test
 
-Tiefe pro Thema im Referenz-Guide `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md` (Anhaenge A-G).
+Per-topic depth in the reference guide `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md` (appendices A-G).
 
 ---
 
-Du fuehrst den User durch den kompletten Lifecycle eines PSADT-v4.x-Intune-Pakets: Intake, Recherche, Scaffold, Customizing, Pre-Flight, Packen, Intune-Upload, Test, Rollout. Verhaltensregeln:
+You guide the user through the complete lifecycle of a PSADT v4.x Intune package: intake, research, scaffold, customizing, pre-flight, packaging, Intune upload, test, rollout. Behavior rules:
 
-- **Fahre die Konversation aktiv** - dump keine Frageliste sondern stell gezielt Blocker-Fragen, recherchiere was recherchierbar ist, zeig dem User Zwischenergebnisse
-- **Fragen IMMER per `AskUserQuestion` (Klick-Optionen) stellen, nie als reinen Fliesstext** - jede Entscheidungsfrage an den User laeuft ueber das `AskUserQuestion`-Tool mit vorausgefuellten, anklickbaren Optionen. Empfohlene Option immer zuerst und mit Suffix "(empfohlen)". Recherchierte Defaults als Optionen anbieten. Das Tool ergaenzt automatisch eine "Other"-Freitext-Option - es muss also keine manuelle Freitext-Alternative gebaut werden. Reiner Text ist nur fuer Zwischenergebnisse/Statusmeldungen erlaubt, nicht fuer Fragen.
-- **Nicht Adobe/Oracle als Default annehmen** - die zu paketierende App kommt immer vom User, Beispiele aus dem Guide sind Illustration
-- **Nachschlag**: Vollstaendiger Referenz-Guide liegt unter `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md` - dort auf konkrete Anhaenge (A-G) verweisen wenn Tiefe noetig, NICHT den ganzen Guide in die Konversation kippen
+- **Actively drive the conversation** - do not dump a question list; ask targeted blocker questions, research what can be researched, show the user intermediate results
+- **ALWAYS ask questions via `AskUserQuestion` (click options), never as plain free text** - every decision question to the user goes through the `AskUserQuestion` tool with pre-filled, clickable options. Always put the recommended option first and mark it with the suffix "(recommended)". Offer researched defaults as options. The tool automatically adds an "Other" free-text option - so there is no need to build a manual free-text alternative. Plain text is only allowed for intermediate results / status messages, not for questions.
+- **Do not assume Adobe/Oracle as default** - the app to be packaged always comes from the user; examples from the guide are illustration
+- **Reference**: The complete reference guide is at `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md` - point to specific appendices (A-G) there when depth is needed, do NOT dump the whole guide into the conversation
 
-## Konventionen (VERBINDLICH)
+## Conventions (BINDING)
 
-- **Sprache - getrennt nach Ziel:**
-  - **Intune-Beschreibung / Dossier (`Intune-Dossier.html`, komplett HTML): Sprache aus `language.dossier`, Default DEUTSCH mit echten Umlauten** (ä, ö, ü, ß) - das ist Endnutzer-Text fuer das Company Portal, dort sind Umlaute korrekt und erwuenscht (KEIN ae/oe/ue ausschreiben). Die Dossier-Sprache ist ein Config-Wert, keine feste Regel.
-  - **In den Scripts selbst (Invoke-AppDeployToolkit.ps1, Extensions, Detection): ALLES auf ENGLISCH** - insb. alle Kommentare. Script-Strings ebenfalls Englisch halten, damit keine Umlaute/Non-ASCII ins PS1 geraten (Encoding-Sauberkeit, siehe Pre-Flight). Umlaute gehoeren NUR in die Dossier-Markdown, nie ins Script.
-- **Author IMMER:** `Patrick Taubert, PHAT Consulting GmbH` (Feld `AppScriptAuthor` im `$adtSession`).
-- **Versionierung des Scripts (`AppScriptVersion` im `$adtSession`):**
-  - Erste Version eines Scripts ist IMMER **`0.1`** (nicht 1.0.0).
-  - Jede inhaltlich gerechtfertigte Aenderung erhoeht die Versionsnummer (kleine Fixes/Klarstellungen -> Patch/Minor, groessere funktionale Aenderungen -> groesserer Sprung). Rein kosmetische Edits ohne Funktionsbezug muessen nicht zwingend hochzaehlen.
-- **Changelog ist Pflicht:** Jede Aenderung an einem Script wird in einem **Changelog im Script-Header (`.NOTES`-Block)** dokumentiert - eine Zeile pro Version: `Version (Datum, Author): Was geaendert wurde`. Bei jeder Aenderung den Changelog-Eintrag UND `AppScriptVersion` zusammen aktualisieren. Format:
+- **Language - split by target:**
+  - **Intune description / dossier (`Intune-Dossier.html`, full HTML): language from `language.dossier`, default GERMAN with real umlauts** (ä, ö, ü, ß) - this is end-user text for the Company Portal, where umlauts are correct and desired (do NOT spell out ae/oe/ue). The dossier language is a config value, not a fixed rule.
+  - **In the scripts themselves (Invoke-AppDeployToolkit.ps1, Extensions, Detection): EVERYTHING in ENGLISH** - especially all comments. Keep script strings in English too, so that no umlauts/non-ASCII end up in the PS1 (encoding cleanliness, see pre-flight). Umlauts belong ONLY in the dossier HTML, never in the script.
+- **Author ALWAYS:** `Patrick Taubert, PHAT Consulting GmbH` (field `AppScriptAuthor` in `$adtSession`).
+- **Script versioning (`AppScriptVersion` in `$adtSession`):**
+  - The first version of a script is ALWAYS **`0.1`** (not 1.0.0).
+  - Every substantively justified change increases the version number (small fixes/clarifications -> patch/minor, larger functional changes -> bigger jump). Purely cosmetic edits without functional relevance do not necessarily need to bump.
+- **Changelog is mandatory:** Every change to a script is documented in a **changelog in the script header (`.NOTES` block)** - one line per version: `Version (date, author): What was changed`. On every change, update the changelog entry AND `AppScriptVersion` together. Format:
   ```
   Changelog:
   - 0.1 (YYYY-MM-DD, Patrick Taubert): Initial version.
-  - 0.2 (YYYY-MM-DD, Patrick Taubert): <was geaendert wurde>.
+  - 0.2 (YYYY-MM-DD, Patrick Taubert): <what was changed>.
   ```
 
-## Ablauf (fuehre in dieser Reihenfolge durch)
+## Workflow (execute in this order)
 
-### 0. Setup (Phase 0 — vor Intake ausfuehren)
+### 0. Setup (Phase 0 — run before intake)
 
-Bevor irgendetwas anderes passiert: sicherstellen, dass der Skill konfiguriert ist und die Voraussetzungen vorhanden sind.
+Before anything else happens: make sure the skill is configured and the prerequisites are in place.
 
-1. `pwsh scripts/Get-PsadtConfig.ps1` ausfuehren. Wenn `Exists` true und `Missing` leer ist, direkt weiter zu Intake.
-2. Wenn Config fehlt/unvollstaendig ist, den **Setup-Wizard** fahren — nur die fehlenden Werte abfragen, IMMER per `AskUserQuestion` (Klick-Optionen), empfohlene Option zuerst:
-   - **Pfade**: `paths.packageRoot`, `paths.outputRoot`, `paths.intuneWinAppUtil` (aktuelle Werte als Defaults anbieten).
-   - **Sprachen**: `language.script` (EN), `language.dossier` (DE als Default — aber Config-Wert, nicht fest).
+1. Run `pwsh scripts/Get-PsadtConfig.ps1`. If `Exists` is true and `Missing` is empty, go straight to intake.
+2. If the config is missing/incomplete, run the **setup wizard** — ask only for the missing values, ALWAYS via `AskUserQuestion` (click options), recommended option first:
+   - **Paths**: `paths.packageRoot`, `paths.outputRoot`, `paths.intuneWinAppUtil` (offer the current values as defaults).
+   - **Languages**: `language.script` (EN), `language.dossier` (DE as default — but a config value, not fixed).
    - **Author**: `author.person`, `author.company`.
-   - **Intune-Upload** *(fuer eine zukuenftige Version geplant — in dieser Version NICHT aktiv)*: darauf hinweisen, dass es kommt; KEINE Tenant-/Client-ID/Secret abfragen, `intune.uploadEnabled` NICHT setzen. Das fertige `.intunewin` wird vorerst manuell im Admin Center hochgeladen.
-3. Antworten mit `scripts/Set-PsadtConfig.ps1 -Updates @{ ... }` persistieren (in dieser Version ohne `-Secret`).
-4. Voraussetzungen provisionieren (den User nie blockieren):
-   - `pwsh scripts/Get-PsadtModule.ps1` — installiert/aktualisiert PSAppDeployToolkit.
-   - `pwsh scripts/Get-IntuneWinAppUtil.ps1` — laedt/aktualisiert das Content-Prep-Tool nach `tools/`.
-5. Jederzeit per "psadt setup" erneut triggerbar, um einzelne Werte zu aendern.
+   - **Intune upload** *(planned for a future version — NOT active in this version)*: mention that it is coming; do NOT ask for tenant/client ID/secret, do NOT set `intune.uploadEnabled`. For now the finished `.intunewin` is uploaded manually in the Admin Center.
+3. Persist answers with `scripts/Set-PsadtConfig.ps1 -Updates @{ ... }` (in this version without `-Secret`).
+4. Provision prerequisites (never block the user):
+   - `pwsh scripts/Get-PsadtModule.ps1` — installs/updates PSAppDeployToolkit.
+   - `pwsh scripts/Get-IntuneWinAppUtil.ps1` — downloads/updates the content-prep tool into `tools/`.
+5. Re-triggerable at any time via "psadt setup" to change individual values.
 
-### 1. Intake (sofort am Anfang, bevor irgendwas anderes)
+### 1. Intake (right at the start, before anything else)
 
-Kritisch: Ein PSADT-v4-Paket bedient IMMER drei Deployment-Types — **Install, Uninstall, Repair**. Alle drei muessen von Anfang an mitgeplant werden, nicht erst am Ende.
+Critical: A PSADT v4 package ALWAYS serves three deployment types — **Install, Uninstall, Repair**. All three must be planned from the start, not only at the end.
 
-Stelle die **8 Kill-Fragen ausschliesslich per `AskUserQuestion`-Tool** (anklickbare Optionen), NICHT als Fliesstext-Liste. Da das Tool max. 4 Fragen pro Aufruf erlaubt, in **zwei `AskUserQuestion`-Aufrufen** buendeln (4 + 4). Wo immer moeglich, vorher das Recherchierbare (App, neueste Version, Installer-Typ) leicht antesten und die Befunde als vorausgewaehlte Optionen anbieten - der User klickt dann nur noch bestaetigen oder korrigieren. Jede Frage bekommt sinnvolle Default-Optionen; die empfohlene zuerst mit Suffix "(empfohlen)". Das Tool haengt automatisch eine "Other"-Freitext-Option an.
+Ask the **8 kill questions exclusively via the `AskUserQuestion` tool** (clickable options), NOT as a free-text list. Since the tool allows max. 4 questions per call, bundle them into **two `AskUserQuestion` calls** (4 + 4). Wherever possible, lightly probe what is researchable beforehand (app, latest version, installer type) and offer the findings as pre-selected options - the user then only clicks confirm or correct. Each question gets sensible default options; the recommended one first with the suffix "(recommended)". The tool automatically appends an "Other" free-text option.
 
-Die 8 inhaltlichen Fragen, die abgedeckt sein muessen (auf die zwei Aufrufe verteilen):
-1. **App + exakte Version** - Optionen: erkannte/neueste Version (empfohlen), bekannte Vorversion(en), aus Kontext.
-2. **Installer-Typ** - Optionen: MSI, EXE-Wrapper, MSIX, InstallShield, Squirrel/ZIP/portable, anderes.
-3. **Installer-Quelle** - Optionen: lokal vorhanden (Pfad folgt), runterladen + ins Paket buendeln (empfohlen), zur Laufzeit runterladen.
-4. **Zielgruppe** - Optionen: Required auf Devices, Available im Company Portal, beides; AAD-Gruppen ggf. als Freitext nachziehen.
-5. **Spezielle Config** - Optionen: keine (empfohlen-Default falls nichts bekannt), Registry-Keys, XML/JSON/settings-Datei, Lizenzkey, Service-Account, Branding (multiSelect: true sinnvoll).
-6. **Reboot-Verhalten** - Optionen: nie (empfohlen), empfohlen (3010), erzwungen (1641).
-7. **Uninstall-Semantik** - Optionen fuer "was muss weg": nur App-Dateien, + Registry-Reste, + Scheduled Tasks/Services/Firewall, + User-Daten (multiSelect). Plus separate Frage/Option, was definitiv ERHALTEN bleiben muss (User-Daten, Shared-Komponenten, Nachbar-Produkte gleicher Hersteller). Uninstall-Method (MSI-ProductCode / Registry-UninstallString / eigener Uninstaller) als eigene Frage falls unklar.
-8. **Repair-Semantik** - Optionen: kein Repair noetig, MSI /fa, Config zurueck auf Default, kompletter Reinstall (empfohlen bei ZIP/EXE), Service-Restart.
+The 8 substantive questions that must be covered (spread across the two calls):
+1. **App + exact version** - options: detected/latest version (recommended), known previous version(s), from context.
+2. **Installer type** - options: MSI, EXE wrapper, MSIX, InstallShield, Squirrel/ZIP/portable, other.
+3. **Installer source** - options: available locally (path follows), download + bundle into the package (recommended), download at runtime.
+4. **Target audience** - options: Required on devices, Available in Company Portal, both; pull in AAD groups as free text if needed.
+5. **Special config** - options: none (recommended default if nothing is known), registry keys, XML/JSON/settings file, license key, service account, branding (multiSelect: true makes sense).
+6. **Reboot behavior** - options: never (recommended), recommended (3010), forced (1641).
+7. **Uninstall semantics** - options for "what must go": app files only, + registry leftovers, + scheduled tasks/services/firewall, + user data (multiSelect). Plus a separate question/option for what definitely must be KEPT (user data, shared components, neighboring products from the same vendor). Uninstall method (MSI ProductCode / registry UninstallString / custom uninstaller) as a separate question if unclear.
+8. **Repair semantics** - options: no repair needed, MSI /fa, config reset to default, complete reinstall (recommended for ZIP/EXE), service restart.
 
-Optional je nach Kontext per weiteren `AskUserQuestion`-Aufruf nachziehen: Co-Existenz mit Vorversionen, Prozesse-schliessen-Liste, Sprache (EN/DE/Multi), Architektur (x64/x86/ARM64). Nicht alle 30 Fragen aus Guide Phase 0.2 auf einmal - Rest kommt situativ, ebenfalls per Klick-Optionen.
+Optionally follow up depending on context via a further `AskUserQuestion` call: co-existence with previous versions, processes-to-close list, language (EN/DE/Multi), architecture (x64/x86/ARM64). Not all 30 questions from guide Phase 0.2 at once - the rest comes situationally, also via click options.
 
-### 2. Web-Recherche (parallel, autonom)
+### 2. Web research (parallel, autonomous)
 
-Nach Intake ohne Rueckfrage sofort **drei parallele Recherchen**:
+After intake, without asking back, immediately run **three parallel research streams**:
 
-**a) PSADT-Version sync UND Command-Aenderungen pruefen:**
+**a) Check PSADT version sync AND command changes:**
 ```powershell
 $local = (Get-Module -ListAvailable -Name PSAppDeployToolkit | Sort-Object Version -Descending | Select-Object -First 1).Version
 $rel = Invoke-RestMethod 'https://api.github.com/repos/PSAppDeployToolkit/PSAppDeployToolkit/releases/latest'
 "local=$local latest=$($rel.tag_name)"
 ```
-Wenn divergent: User informieren + `Update-Module PSAppDeployToolkit -Force` empfehlen BEVOR Scaffold.
+If divergent: inform the user + recommend `Update-Module PSAppDeployToolkit -Force` BEFORE scaffold.
 
-**Pflicht, NICHT nur die Versionsnummer vergleichen:** Bei abweichender (neuerer) Version IMMER pruefen, ob sich
-**Commands geaendert haben** - neue, umbenannte, deprecated oder mit geaenderten Parametern. Sonst baut man ein
-Paket mit veralteter Syntax, das beim Launcher-Acid-Test oder erst in Intune bricht. Quellen in dieser Reihenfolge:
-- Release Notes des neuesten Releases: `$rel.body` (oben schon geladen) auf "Breaking", "renamed", "deprecated", "removed", "new function" scannen
-- Changelog/Migration-Doku: https://psappdeploytoolkit.com/docs (v3->v4 Function-Mapping und Versions-Changelogs)
-- GitHub Releases-Uebersicht: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/releases
-- Im Zweifel die konkret genutzten Cmdlets gegen das installierte Modul verifizieren:
+**Mandatory, do NOT just compare the version number:** On a divergent (newer) version ALWAYS check whether
+**commands have changed** - new, renamed, deprecated, or with changed parameters. Otherwise you build a
+package with outdated syntax that breaks at the launcher acid test or only later in Intune. Sources in this order:
+- Release notes of the latest release: `$rel.body` (already loaded above) scanned for "Breaking", "renamed", "deprecated", "removed", "new function"
+- Changelog/migration docs: https://psappdeploytoolkit.com/docs (v3->v4 function mapping and version changelogs)
+- GitHub releases overview: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/releases
+- When in doubt, verify the actually used cmdlets against the installed module:
   `Get-Command -Module PSAppDeployToolkit -Name Start-ADTProcess,Start-ADTMsiProcess,Show-ADTInstallationWelcome,New-ADTShortcut,Remove-ADTFolder | Select Name,Version`
-  und bei Bedarf `Get-Help <Cmdlet> -Parameter *` fuer geaenderte Parameter.
-Befund dem User zeigen (welche Commands neu/geaendert/deprecated sind und was das fuers Paket bedeutet) BEVOR gebaut wird.
+  and if needed `Get-Help <Cmdlet> -Parameter *` for changed parameters.
+Show the finding to the user (which commands are new/changed/deprecated and what that means for the package) BEFORE building.
 
-**b) Silent-Install / Uninstall / Repair-Recherche zur App** via WebSearch — ALLE DREI, nicht nur Install:
+**b) Silent install / uninstall / repair research on the app** via WebSearch — ALL THREE, not just install:
 - Query 1: `"<AppName>" "<Version>" silent install command line`
 - Query 2: `"<AppName>" msi transform enterprise deployment`
 - Query 3: `"<AppName>" uninstall silent /quiet /qn msiexec`
-- Query 4: `"<AppName>" repair reinstall command line` (oft `msiexec /fa <ProductCode>` bei MSIs; bei EXE-Wrappers: reinstall ueber den gleichen Installer)
-- Query 5: `"<AppName>" "uninstall" "registry" "leftover"` — dokumentierte Leichen aus der Community
-- Offizielle Hersteller-Docs zuerst, dann silentinstallhq.com, dann Community (Reddit r/Intune, PSADT Discourse)
+- Query 4: `"<AppName>" repair reinstall command line` (often `msiexec /fa <ProductCode>` for MSIs; for EXE wrappers: reinstall via the same installer)
+- Query 5: `"<AppName>" "uninstall" "registry" "leftover"` — documented leftovers from the community
+- Official vendor docs first, then silentinstallhq.com, then community (Reddit r/Intune, PSADT Discourse)
 
-Ergebnis pro Deployment-Type festhalten: Switch, erwartete Exit-Codes, Log-Pfad, bekannte Leichen.
+Record per deployment type: switch, expected exit codes, log path, known leftovers.
 
-**c) Bekannte Intune-Stolpersteine:**
+**c) Known Intune pitfalls:**
 - Query: `"<AppName>" intune win32 known issues`
-- Query: `"<AppName>" PSADT package github` (falls jemand schon ein Paket gebaut hat)
+- Query: `"<AppName>" PSADT package github` (in case someone already built a package)
 
-Ergebnis in die Phase-0.3-Tabelle aus dem Guide packen und dem User zeigen BEVOR das Scaffold gebaut wird.
+Put the result into the Phase-0.3 table from the guide and show it to the user BEFORE the scaffold is built.
 
 ### 3. Scaffold (`New-ADTTemplate`)
 
-Werte aus Intake + Recherche einsetzen. **NICHT hardcoden**, **nicht Adobe/Oracle nehmen**.
+Insert values from intake + research. **Do NOT hardcode**, **do not use Adobe/Oracle**.
 
 ```powershell
 Import-Module PSAppDeployToolkit
-# WICHTIG: New-ADTTemplate akzeptiert in 4.1.x NUR -Destination/-Name/-Version (Modulversion)/-Force/-Show/-PassThru.
-# Es nimmt KEINE App-Metadaten (-AppVendor/-AppName/-AppVersion/-AppScriptAuthor ...). Die kommen NACH dem Scaffold
-# ins $adtSession-Hashtable im Invoke-AppDeployToolkit.ps1.
-New-ADTTemplate -Destination '<Root-aus-User-Angabe>' -Name '<AppName aus Intake>'
+# IMPORTANT: In 4.1.x, New-ADTTemplate ONLY accepts -Destination/-Name/-Version (module version)/-Force/-Show/-PassThru.
+# It takes NO app metadata (-AppVendor/-AppName/-AppVersion/-AppScriptAuthor ...). Those go AFTER the scaffold
+# into the $adtSession hashtable in Invoke-AppDeployToolkit.ps1.
+New-ADTTemplate -Destination '<root-from-user-input>' -Name '<AppName from intake>'
 ```
 
-Danach im erzeugten `Invoke-AppDeployToolkit.ps1` das `$adtSession`-Hashtable fuellen - inkl. der verbindlichen Konventionen:
+Then fill the `$adtSession` hashtable in the generated `Invoke-AppDeployToolkit.ps1` - including the binding conventions:
 ```powershell
-AppVendor = '<Hersteller>'
-AppName = '<Produkt-Kurzname>'
-AppVersion = '<Version>'
+AppVendor = '<vendor>'
+AppName = '<short product name>'
+AppVersion = '<version>'
 AppArch = '<x64|x86|ARM64>'
 AppLang = 'EN'
 AppRevision = '01'
 AppSuccessExitCodes = @(0, 1707)
 AppRebootExitCodes = @(1641, 3010)
-AppScriptVersion = '0.1'                              # erste Version IMMER 0.1, siehe Konventionen
-AppScriptAuthor = 'Patrick Taubert, PHAT Consulting GmbH'   # IMMER dieser Author
+AppScriptVersion = '0.1'                              # first version ALWAYS 0.1, see conventions
+AppScriptAuthor = 'Patrick Taubert, PHAT Consulting GmbH'   # ALWAYS this author
 ```
-Und im Header-Kommentar (`.NOTES`) den Changelog anlegen: `- 0.1 (YYYY-MM-DD, Patrick Taubert): Initial version.`
+And in the header comment (`.NOTES`) create the changelog: `- 0.1 (YYYY-MM-DD, Patrick Taubert): Initial version.`
 
-Verify direkt nach Scaffold:
+Verify right after scaffold:
 ```powershell
-$pkg = '<Scaffold-Pfad>'
+$pkg = '<scaffold path>'
 (Import-PowerShellDataFile "$pkg\PSAppDeployToolkit\PSAppDeployToolkit.psd1").ModuleVersion
 Select-String "$pkg\Invoke-AppDeployToolkit.ps1" -Pattern 'DeployAppScriptVersion' -List | Select-Object Line
 ```
-Beides muss matchen.
+Both must match.
 
-### 4. Script-Customizing — alle drei Deployment-Types
+### 4. Script customizing — all three deployment types
 
-Der User legt Installer in `<pkg>\Files\`. Dann in `Invoke-AppDeployToolkit.ps1` **alle drei Hooks** fuellen: `Install-ADTDeployment`, `Uninstall-ADTDeployment`, `Repair-ADTDeployment`. Auch wenn heute nur Install gebraucht ist: spaetere User-Uninstalls via Company Portal funktionieren nur mit gefuelltem Uninstall-Block.
+The user places the installer in `<pkg>\Files\`. Then fill **all three hooks** in `Invoke-AppDeployToolkit.ps1`: `Install-ADTDeployment`, `Uninstall-ADTDeployment`, `Repair-ADTDeployment`. Even if only install is needed today: later user uninstalls via Company Portal only work with a filled uninstall block.
 
-**4a. `Install-ADTDeployment`** — Pattern je nach Installer-Typ aus der Recherche:
+**4a. `Install-ADTDeployment`** — pattern depending on installer type from the research:
 
 - MSI: `Start-ADTMsiProcess -FilePath "$($adtSession.DirFiles)\<installer>.msi" -Transforms "$($adtSession.DirSupportFiles)\<transform>.mst" -ArgumentList '/qn REBOOT=ReallySuppress'`
-- EXE-Wrapper: `Start-ADTProcess -FilePath "$($adtSession.DirFiles)\<setup>.exe" -ArgumentList '<recherchierte-silent-switches>' -SuccessExitCodes @(0, 3010, 1641)`
-- InstallShield mit `setup.exe /s /f1"<response>.iss"`: Response-File in `SupportFiles\`
-- Squirrel (`<app>-<ver>-full.nupkg`-based .exe): oft `/silent /quiet`
+- EXE wrapper: `Start-ADTProcess -FilePath "$($adtSession.DirFiles)\<setup>.exe" -ArgumentList '<researched silent switches>' -SuccessExitCodes @(0, 3010, 1641)`
+- InstallShield with `setup.exe /s /f1"<response>.iss"`: response file in `SupportFiles\`
+- Squirrel (`<app>-<ver>-full.nupkg`-based .exe): often `/silent /quiet`
 
-Pflicht vor Install: `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CheckDiskSpace -RequiredDiskSpace <MB>` (no-op in Silent, aktiv in Interactive). Dann `Show-ADTInstallationProgress` fuer die Welcome-Ersatz-Anzeige.
+Mandatory before install: `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CheckDiskSpace -RequiredDiskSpace <MB>` (no-op in silent, active in interactive). Then `Show-ADTInstallationProgress` for the welcome-replacement display.
 
-**Verknuepfungen - NUR Startmenue, NIE Desktop:** Wenn die App eine Verknuepfung braucht, ausschliesslich einen
-Startmenue-Eintrag fuer alle User anlegen (`$envCommonStartMenuPrograms`, z.B.
-`New-ADTShortcut -Path "$envCommonStartMenuPrograms\<App>\<App>.lnk" -TargetPath ...`). **Keine Desktop-Icons**
-(`$envCommonDesktop` / `$envUserDesktop`) erstellen - das verschmutzt den Desktop und ist im Enterprise unerwuenscht.
-Falls der Installer von sich aus ein Desktop-Icon anlegt: im Post-Install gezielt wieder entfernen
-(`Remove-Item "$envCommonDesktop\<App>.lnk"`). Im Uninstall den Startmenue-Eintrag wieder mit abraeumen.
+**Shortcuts - ONLY Start Menu, NEVER desktop:** If the app needs a shortcut, create exclusively a
+Start Menu entry for all users (`$envCommonStartMenuPrograms`, e.g.
+`New-ADTShortcut -Path "$envCommonStartMenuPrograms\<App>\<App>.lnk" -TargetPath ...`). **No desktop icons**
+(`$envCommonDesktop` / `$envUserDesktop`) - that clutters the desktop and is unwanted in the enterprise.
+If the installer creates a desktop icon on its own: remove it again specifically in post-install
+(`Remove-Item "$envCommonDesktop\<App>.lnk"`). In uninstall, clean up the Start Menu entry as well.
 
-**4b. `Uninstall-ADTDeployment`** — Werte aus Intake-Frage 7 (was weg, was bleibt):
+**4b. `Uninstall-ADTDeployment`** — values from intake question 7 (what goes, what stays):
 
-- MSI bekannter ProductCode: `Start-ADTMsiProcess -Action Uninstall -FilePath '{<ProductCode>}' -ArgumentList '/qn'`
-- MSI per DisplayName-Match (wenn ProductCode variiert): `Remove-ADTApplication -Name '<AppName>' -NameMatch Exact` (nicht `Contains` - das loescht versehentlich Nachbar-Produkte mit Namens-Prefix)
-- EXE mit eigenem Uninstaller: `Start-ADTProcess -FilePath '<uninstallstring-aus-registry>' -ArgumentList '<silent-uninstall-switches>'`
+- MSI with known ProductCode: `Start-ADTMsiProcess -Action Uninstall -FilePath '{<ProductCode>}' -ArgumentList '/qn'`
+- MSI via DisplayName match (when ProductCode varies): `Remove-ADTApplication -Name '<AppName>' -NameMatch Exact` (not `Contains` - that accidentally removes neighboring products with a name prefix)
+- EXE with its own uninstaller: `Start-ADTProcess -FilePath '<uninstallstring-from-registry>' -ArgumentList '<silent uninstall switches>'`
 - Squirrel: `Start-ADTProcess -FilePath "$env:LocalAppData\<app>\update.exe" -ArgumentList '--uninstall -s'`
 
-Post-Uninstall-Cleanup (anhand Intake-Frage 7):
-- `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CloseProcessesCountdown 60` (nicht `-Silent` - Uninstalls sollten Prozesse killen durfen)
-- Scheduled Tasks: `Get-ScheduledTask -TaskName '<Prefix>_*' | Unregister-ScheduledTask -Confirm:$false`
-- Services: `Stop-Service <Name>` + `sc.exe delete <Name>` fuer Services die der Installer nicht selbst wegraeumt
-- Firewall-Rules: `Get-NetFirewallRule -DisplayName '<App>*' | Remove-NetFirewallRule`
-- Registry-Leichen: gezielt nur unter dem APP-spezifischen Key loeschen, NIE unter `HKLM\SOFTWARE\<Hersteller>\` pauschal (andere Produkte gleicher Firma leiden)
-- Install-Directory `Remove-Item -Recurse` wenn Installer nicht von selbst aufraeumt
-- User-Daten (AppData, Dokumente, Templates): DEFAULT **behalten**, nur auf explizite Intake-7-Anweisung entfernen (und dann gezielt per `Invoke-ADTAllUsersRegistryAction` / `$envProfilesDirectory`-Iteration pro User)
+Post-uninstall cleanup (based on intake question 7):
+- `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CloseProcessesCountdown 60` (not `-Silent` - uninstalls should be allowed to kill processes)
+- Scheduled tasks: `Get-ScheduledTask -TaskName '<Prefix>_*' | Unregister-ScheduledTask -Confirm:$false`
+- Services: `Stop-Service <Name>` + `sc.exe delete <Name>` for services the installer does not clean up itself
+- Firewall rules: `Get-NetFirewallRule -DisplayName '<App>*' | Remove-NetFirewallRule`
+- Registry leftovers: delete specifically only under the APP-specific key, NEVER under `HKLM\SOFTWARE\<vendor>\` wholesale (other products of the same company suffer)
+- Install directory `Remove-Item -Recurse` if the installer does not clean up on its own
+- User data (AppData, documents, templates): DEFAULT **keep**, only remove on explicit intake-7 instruction (and then specifically via `Invoke-ADTAllUsersRegistryAction` / `$envProfilesDirectory` iteration per user)
 
-Gegenbeispiel zum Warnen: NIE `Remove-Item 'HKLM:\SOFTWARE\<Hersteller>' -Recurse` machen. Immer APP-Sub-Key.
+Counter-example to warn about: NEVER do `Remove-Item 'HKLM:\SOFTWARE\<vendor>' -Recurse`. Always the APP sub-key.
 
-**4c. `Repair-ADTDeployment`** — Werte aus Intake-Frage 8:
+**4c. `Repair-ADTDeployment`** — values from intake question 8:
 
-- Wenn in Intake "nicht benoetigt": Hook leer lassen oder mit `Write-ADTLogEntry -Message 'Repair nicht unterstuetzt - bitte Uninstall + Install nutzen.'` + `throw` abbrechen
-- MSI: `Start-ADTMsiProcess -Action Repair -FilePath '{<ProductCode>}' -ArgumentList '/fa /qn'` (`/fa` = alle Files neu, Shortcuts + Registry werden erneut gesetzt)
-- EXE-Wrapper ohne dedizierten Repair-Modus: Uninstall gefolgt von Install im selben Hook; User-Config moeglichst erhalten (Backup-Wiederherstell-Logik wenn noetig)
-- Config-Only-Repair: Service stoppen, Config-Files aus `SupportFiles\` zurueckkopieren, Service starten - ohne die App neu zu installieren (schneller, weniger invasiv)
+- If intake says "not needed": leave the hook empty or abort with `Write-ADTLogEntry -Message 'Repair not supported - please use Uninstall + Install.'` + `throw`
+- MSI: `Start-ADTMsiProcess -Action Repair -FilePath '{<ProductCode>}' -ArgumentList '/fa /qn'` (`/fa` = all files reinstalled, shortcuts + registry are set again)
+- EXE wrapper without a dedicated repair mode: uninstall followed by install in the same hook; preserve user config if possible (backup-restore logic if needed)
+- Config-only repair: stop the service, copy the config files back from `SupportFiles\`, start the service - without reinstalling the app (faster, less invasive)
 
-**Custom-Helpers** IMMER in `<pkg>\PSAppDeployToolkit.Extensions\PSAppDeployToolkit.Extensions.psm1`, nie im Main-Script.
+**Custom helpers** ALWAYS in `<pkg>\PSAppDeployToolkit.Extensions\PSAppDeployToolkit.Extensions.psm1`, never in the main script.
 
-### 5. Pre-Flight-Checks (Pflicht vor Packen)
+### 5. Pre-flight checks (mandatory before packaging)
 
-Dreimal gruen pro Deployment-Type, sonst nicht weiter:
+Three green per deployment type, otherwise do not proceed:
 
 ```powershell
-$s = '<pfad-zur-ps1>'
+$s = '<path-to-ps1>'
 
 # Check 1: Encoding
 $bytes = [System.IO.File]::ReadAllBytes($s)
 $hasBom = $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF
 $text = [System.IO.File]::ReadAllText($s, [System.Text.Encoding]::UTF8)
 $nonAscii = ([regex]::Matches($text, '[^\x00-\x7F]')).Count
-"HasBOM=$hasBom NonAscii=$nonAscii"   # Anforderung: HasBOM=True ODER NonAscii=0
+"HasBOM=$hasBom NonAscii=$nonAscii"   # Requirement: HasBOM=True OR NonAscii=0
 
 # Check 2: Parse
 $errs = $null
 $null = [System.Management.Automation.Language.Parser]::ParseFile($s, [ref]$null, [ref]$errs)
 if ($errs) { $errs | Select Message,@{N='L';E={$_.Extent.StartLineNumber}} | Format-List } else { 'PARSE_OK' }
 
-# Check 3: Launcher-Acid-Test pro Deployment-Type (je einmal)
+# Check 3: Launcher acid test per deployment type (once each)
 foreach ($dt in 'Install','Uninstall','Repair') {
     "--- Acid-Test $dt ---"
     Start-Process powershell.exe -ArgumentList `
         '-ExecutionPolicy','Bypass','-NonInteractive','-NoProfile','-NoLogo',`
         '-Command', "try { & '$s' -DeploymentType $dt -DeployMode Silent } catch { throw }; exit `$Global:LASTEXITCODE" `
         -Wait -NoNewWindow -RedirectStandardError "stderr-$dt.log"
-    Get-Content "stderr-$dt.log"   # Darf keine Parse-Errors zeigen
+    Get-Content "stderr-$dt.log"   # Must show no parse errors
 }
 ```
 
-Wenn einer der drei Types rot wird: das ist NICHT ok auch wenn Install gruen ist. Company-Portal-User kriegt sonst beim Uninstall-Klick 0x80070001.
+If one of the three types turns red: that is NOT ok even if install is green. Otherwise the Company Portal user gets 0x80070001 when clicking uninstall.
 
-Bei Encoding-Bug (Check 1 rot oder Check 3 Parse-Errors): Em-Dashes / Smart-Quotes ersetzen + UTF-8 BOM:
+On an encoding bug (check 1 red or check 3 parse errors): replace em-dashes / smart quotes + UTF-8 BOM:
 ```powershell
 $text = [System.IO.File]::ReadAllText($s, [System.Text.Encoding]::UTF8)
 $text = $text -replace [char]0x2014, '-' -replace [char]0x2013, '-' -replace [char]0x2192, '->' `
@@ -245,33 +245,35 @@ $text = $text -replace [char]0x2014, '-' -replace [char]0x2013, '-' -replace [ch
 [System.IO.File]::WriteAllText($s, $text, [System.Text.UTF8Encoding]::new($true))
 ```
 
-Bei Check 3 zu gefaehrlich weil echter Install starten wuerde: Test-Stub aus Guide Anhang C verwenden (Install-ADTDeployment-Call ersetzen durch `exit 77`-Stub, Launcher-Test, erwartet Exit 77).
+If check 3 is too dangerous because a real install would start: use the test stub from guide appendix C (replace the Install-ADTDeployment call with an `exit 77` stub, launcher test, expects exit 77).
 
-Zusaetzlich scannen:
+Additionally scan:
 ```powershell
-# v3-Reste
+# v3 leftovers
 $v3 = 'Execute-Process','Execute-MSI','Write-Log','Show-InstallationWelcome','Show-InstallationProgress','Show-InstallationPrompt','Get-InstalledApplication','Remove-MSIApplications','Refresh-Desktop','Update-GroupPolicy','Block-AppExecution'
 $t = [System.IO.File]::ReadAllText($s)
 foreach ($fn in $v3) { $m = [regex]::Matches($t, "\b$fn\b"); if ($m.Count) { "V3_FOUND: $fn ($($m.Count)x)" } }
 
-# Top-Level-Statements die werfen koennten
+# Top-level statements that could throw
 $ast = [System.Management.Automation.Language.Parser]::ParseFile($s, [ref]$null, [ref]$null)
 $ast.EndBlock.Statements | Where-Object { $_ -isnot [System.Management.Automation.Language.FunctionDefinitionAst] } |
     ForEach-Object { "L$($_.Extent.StartLineNumber): $($_.GetType().Name)" }
 ```
 
-### 6. Packen mit IntuneWinAppUtil
+### 6. Packaging with IntuneWinAppUtil
 
-**Output-Ordner-Konvention (VERBINDLICH, nicht jedes Mal woanders):** Das fertige `.intunewin` IMMER nach
-`c:\Temp\PSADTv4\Output\<AppName[-Version]>\` legen - ein zentraler `Output`-Ordner im PSADTv4-Hauptverzeichnis,
-darunter ein Unterordner pro App (z.B. `Output\EclipseJEE\`, `Output\RSAT-1.0.0\`, `Output\ApacheMaven-3.9.16\`).
-NIE einen eigenen `_IntuneOutput`/`<App>-IntuneOutput`-Ordner neben dem Paket anlegen. In den App-Unterordner gehoeren
-neben der `.intunewin` auch das Detection-Script und das Intune-Dossier (1 Ort pro App, alles beisammen).
-Wichtig: `-c` (Source) ist der PAKET-Ordner, `-o` (Output) ist der zentrale Output-Unterordner - die beiden sind
-verschiedene Baeume, also liegt `-o` automatisch AUSSERHALB von `-c`.
+**Tool path and version are config-driven** (`paths.intuneWinAppUtil`) and are provisioned and kept current by `scripts/Get-IntuneWinAppUtil.ps1` (the inline download below stays as a manual fallback).
+
+**Output folder convention (BINDING, not somewhere different each time):** ALWAYS place the finished `.intunewin` into
+`c:\Temp\PSADTv4\Output\<AppName[-Version]>\` - a central `Output` folder in the PSADTv4 main directory,
+with a sub-folder per app underneath (e.g. `Output\EclipseJEE\`, `Output\RSAT-1.0.0\`, `Output\ApacheMaven-3.9.16\`).
+NEVER create a separate `_IntuneOutput`/`<App>-IntuneOutput` folder next to the package. The app sub-folder holds,
+besides the `.intunewin`, also the detection script and the Intune dossier (1 place per app, everything together).
+Important: `-c` (source) is the PACKAGE folder, `-o` (output) is the central output sub-folder - the two are
+different trees, so `-o` automatically lies OUTSIDE `-c`.
 
 ```powershell
-# IntuneWinAppUtil holen (das GitHub-Release hat KEINE Assets - exe liegt im Repo-Tree, daher raw-Download)
+# Fetch IntuneWinAppUtil (the GitHub release has NO assets - the exe lives in the repo tree, hence raw download)
 $tool = 'C:\Tools\IntuneWinAppUtil.exe'
 if (-not (Test-Path $tool)) {
     New-Item 'C:\Tools' -ItemType Directory -Force | Out-Null
@@ -279,159 +281,161 @@ if (-not (Test-Path $tool)) {
     Invoke-WebRequest "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw/$tag/IntuneWinAppUtil.exe" -OutFile $tool
 }
 
-$src = '<pkgFolder>'                                            # Paket-Ordner mit Invoke-AppDeployToolkit.ps1/.exe
-$out = 'c:\Temp\PSADTv4\Output\<AppName[-Version]>'             # ZENTRAL, pro-App-Unterordner
+$src = '<pkgFolder>'                                            # package folder with Invoke-AppDeployToolkit.ps1/.exe
+$out = 'c:\Temp\PSADTv4\Output\<AppName[-Version]>'             # CENTRAL, per-app sub-folder
 New-Item $out -ItemType Directory -Force | Out-Null
 & $tool -c $src -s 'Invoke-AppDeployToolkit.exe' -o $out -q
-# Detection-Script + Dossier daneben legen (Dossier IMMER als Intune-Dossier.md):
+# Place the detection script + dossier alongside (dossier ALWAYS as Intune-Dossier.html):
 Copy-Item '<pkgFolder>\Detect-*.ps1' $out -Force -ErrorAction SilentlyContinue
-Copy-Item '<pkgFolder>\Intune-Dossier.md' $out -Force -ErrorAction SilentlyContinue
+Copy-Item '<pkgFolder>\Intune-Dossier.html' $out -Force -ErrorAction SilentlyContinue
 ```
 
-**Kritisch**: `-o` NIE INNERHALB von `-c` waehlen - sonst landet beim Rebuild die alte .intunewin rekursiv im Paket.
-Der zentrale `Output\`-Ordner liegt ohnehin ausserhalb jedes Paket-Ordners, das ist genau der Grund fuer die Konvention.
+**Critical**: NEVER choose `-o` INSIDE `-c` - otherwise the old .intunewin lands recursively in the package on rebuild.
+The central `Output\` folder lies outside every package folder anyway, which is exactly the reason for the convention.
 
-Verify der .intunewin:
+Verify the .intunewin:
 ```powershell
 $iw = Get-ChildItem "$out\*.intunewin" | Select-Object -First 1
 "Size: $([Math]::Round($iw.Length / 1MB, 1)) MB"
 Expand-Archive $iw.FullName -DestinationPath "$env:TEMP\iw-check" -Force
 Get-Content "$env:TEMP\iw-check\IntuneWinPackage\Metadata\Detection.xml" | Select-String 'SetupFile'
-# Muss zeigen: <SetupFile>Invoke-AppDeployToolkit.exe</SetupFile>
+# Must show: <SetupFile>Invoke-AppDeployToolkit.exe</SetupFile>
 ```
 
-### 7. Intune-Dossier
+### 7. Intune dossier
 
-Anhang F aus dem Referenz-Guide als Template: die Datei IMMER **`Intune-Dossier.md`** nennen (fixer Name, NICHT `<App>-IntuneDossier.md` oder `Intune-App-Metadata.md` - der App-Name steckt schon im Output-Unterordner) und im zentralen `Output\<App>\`-Ordner ablegen. Alle Tabellen fuellen (App Info, Description-Markdown, Program, Return Codes inkl. 60001/60008=Failed, Requirements, Detection, Dependencies, Supersedence, Assignments). User pruefen lassen, dann er/sie uebertraegt die Werte 1:1 ins Intune Admin Center.
+Use appendix F from the reference guide as a template: ALWAYS name the file **`Intune-Dossier.html`** (fixed name, NOT `<App>-IntuneDossier.html` or `Intune-App-Metadata.html` - the app name is already in the output sub-folder) and place it in the central `Output\<App>\` folder. The dossier is **full HTML**. Fill all tables (App Info, description HTML, Program, Return Codes incl. 60001/60008=Failed, Requirements, Detection, Dependencies, Supersedence, Assignments). Let the user review, then he/she transfers the values 1:1 into the Intune Admin Center.
 
-**App-Logo automatisch besorgen (Pflicht):** Ein passendes Logo der App suchen und herunterladen - **PNG, transparenter Hintergrund, hohe Aufloesung** (Richtwert >= 512px, lieber mehr; quadratisch ist fuer die Company-Portal-Kachel am besten). Ablegen unter `<pkg>\Assets\<App>-Logo.png` UND eine Kopie nach `Output\<App>\`. Im Dossier in der Logo-Zeile den Dateinamen referenzieren.
-- **Quelle lizenzklar waehlen:** zuerst offizielle Hersteller-/Projekt-Quelle (z.B. `apache.org/logos/res/<projekt>/` fuer Apache-Projekte), sonst **Wikimedia Commons** (stabile URLs, SVG wird serverseitig als transparentes PNG gerendert):
+The dossier language follows `language.dossier` (default German), and its umlauts stay (real ä, ö, ü, ß), because it is end-user output for the Company Portal.
+
+**Note: direct Graph upload is planned for a future skill version.** For now the user uploads the generated `.intunewin` manually in the Intune Admin Center.
+
+**Obtain the app logo automatically (mandatory):** Search for and download a suitable logo of the app - **PNG, transparent background, high resolution** (guideline >= 512px, more is better; square is best for the Company Portal tile). Place it under `<pkg>\Assets\<App>-Logo.png` AND a copy into `Output\<App>\`. Reference the filename in the logo row of the dossier.
+- **Choose a license-clear source:** first the official vendor/project source (e.g. `apache.org/logos/res/<project>/` for Apache projects), otherwise **Wikimedia Commons** (stable URLs, SVG is rendered server-side as a transparent PNG):
   ```powershell
-  # Wikimedia: SVG -> transparentes PNG in Wunschbreite (hier 1024)
+  # Wikimedia: SVG -> transparent PNG at the desired width (here 1024)
   $api = "https://commons.wikimedia.org/w/api.php?action=query&titles=$([uri]::EscapeDataString('File:<Logo>.svg'))&prop=imageinfo&iiprop=url&iiurlwidth=1024&format=json"
   $thumb = ((Invoke-RestMethod $api -Headers @{'User-Agent'='PSADT-pkg/1.0'}).query.pages.PSObject.Properties.Value).imageinfo[0].thumburl
   Invoke-WebRequest $thumb -OutFile '<pkg>\Assets\<App>-Logo.png' -Headers @{'User-Agent'='PSADT-pkg/1.0'}
   ```
-  Drittanbieter-PNG-Portale (stickpng, toppng, nicepng ...) meiden - Hotlink-Schutz/Werbung/fragliche Qualitaet.
-- **Verifizieren** (Transparenz + Aufloesung) und dem User zeigen, dass es das richtige Logo ist:
+  Avoid third-party PNG portals (stickpng, toppng, nicepng ...) - hotlink protection/ads/questionable quality.
+- **Verify** (transparency + resolution) and show the user that it is the right logo:
   ```powershell
   Add-Type -AssemblyName System.Drawing
   $i=[System.Drawing.Image]::FromFile('<png>'); "{0}x{1} Alpha={2}" -f $i.Width,$i.Height,[System.Drawing.Image]::IsAlphaPixelFormat($i.PixelFormat); $i.Dispose()
   ```
-  Alpha MUSS True sein (sonst kein transparenter Hintergrund -> anderes File suchen). Das Logo wird in Intune separat im **App-Information-Tab** hochgeladen, ist NICHT Teil des `.intunewin` (kein Repack noetig).
+  Alpha MUST be True (otherwise no transparent background -> look for another file). The logo is uploaded separately in Intune in the **App information tab**, it is NOT part of the `.intunewin` (no repack needed).
 
-**App-Beschreibung IMMER auf DEUTSCH mit echten Umlauten (ä, ö, ü, ß)** - das ist Endnutzer-Text im Company Portal, KEIN ae/oe/ue ausschreiben. (Gilt nur fuer die Dossier-Markdown; die Scripts bleiben Englisch/ASCII - siehe Konventionen.)
+**App description ALWAYS in the dossier language with real umlauts (ä, ö, ü, ß)** - this is end-user text in the Company Portal, do NOT spell out ae/oe/ue. (Applies only to the dossier HTML; the scripts stay English/ASCII - see conventions.)
 
-**App-Beschreibung IMMER in Markdown formatieren** - das Intune-Beschreibungsfeld rendert Markdown (Toolbar-Editor) und stellt es im Company Portal formatiert dar. KEINE reine Fliesstext-Wand. Den Description-Block im Dossier als fertiges Markdown liefern, das der User 1:1 ins Beschreibungsfeld einfuegen kann. Unterstuetzter Funktionsumfang (sicher nutzbar):
-- **Fett** und *kursiv* fuer Hervorhebungen
-- Aufzaehlungslisten (`-`) und nummerierte Listen (`1.`) - ideal fuer Voraussetzungen, gesetzte Variablen, Was-passiert-Schritte
-- Links `[Text](https://...)` fuer Hersteller-/Doku-Seiten
-- Kurze Absaetze statt Block
-- Vorsichtig/sparsam: Ueberschriften und Tabellen (Rendering im Company Portal variiert) - lieber Fett-Zeile + Liste
+**App description ALWAYS formatted as HTML** - the Intune description field has an HTML editor (toolbar) and renders it formatted in the Company Portal. NO plain free-text wall. Deliver the description block in the dossier as ready HTML that the user can paste 1:1 into the description field. Supported feature set (safe to use):
+- `<strong>` (bold) and `<em>` (italic) for emphasis
+- `<ul><li>...</li></ul>` (bulleted) and `<ol><li>...</li></ol>` (numbered) lists - ideal for requirements, set variables, what-happens steps
+- Links `<a href="https://...">Text</a>` for vendor/docs pages
+- Short `<p>` paragraphs instead of a block
 
-Empfohlene Struktur der Beschreibung (anpassen pro App):
-```markdown
-**<AppName> <Version>** - <Ein-Satz-Nutzen>.
-
-**Was diese Bereitstellung macht:**
-- <Installationsziel / Pfad>
-- <gesetzte Umgebungsvariablen / Registry / Config>
-- <besondere Nebenwirkungen>
-
-**Voraussetzungen:**
-- <z.B. JDK, .NET, Vorgängerversion>
-
-**Bei Deinstallation:**
-- <was entfernt wird> / <was erhalten bleibt>
-
-Mehr Infos: [Herstellerseite](https://...)
+Recommended description structure (end-user output — language.dossier, default German; adapt per app):
+```html
+<p><strong>&lt;AppName&gt; &lt;Version&gt;</strong> – &lt;one-sentence value&gt;.</p>
+<p><strong>What this deployment does:</strong></p>
+<ul>
+  <li>&lt;install target / path&gt;</li>
+  <li>&lt;environment variables / registry / config set&gt;</li>
+  <li>&lt;notable side effects&gt;</li>
+</ul>
+<p><strong>Requirements:</strong></p>
+<ul><li>&lt;e.g. JDK, .NET, prior version&gt;</li></ul>
+<p><strong>On uninstall:</strong></p>
+<ul><li>&lt;what is removed&gt; / &lt;what is kept&gt;</li></ul>
+<p>More info: <a href="https://...">Vendor page</a></p>
 ```
 
-Pflicht-Return-Codes die immer rein muessen: `0 Success, 1707 Success, 3010 Soft reboot, 1641 Hard reboot, 1618 Retry, 60001 Failed, 60008 Failed` + installer-spezifische Codes aus der Recherche.
+Mandatory return codes that must always be included: `0 Success, 1707 Success, 3010 Soft reboot, 1641 Hard reboot, 1618 Retry, 60001 Failed, 60008 Failed` + installer-specific codes from the research.
 
-### 8. Test-Sequenz (VOR Production-Rollout) — alle drei Deployment-Types
+### 8. Test sequence (BEFORE production rollout) — all three deployment types
 
-Auf DEV-VM in dieser Reihenfolge. Nach jedem erfolgreichen Install kommt der Uninstall-Test auf **der gleichen VM** (nicht neue VM) - damit Uninstall auch wirklich was zum Abraeumen hat.
+On a DEV VM in this order. After each successful install comes the uninstall test on **the same VM** (not a new VM) - so that uninstall actually has something to clean up.
 
-**Install-Zyklus:**
-1. `.\Invoke-AppDeployToolkit.ps1 -DeploymentType Install -DeployMode Silent` (Smoke-Test)
-2. `.\Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent` (Launcher-Acid-Test)
-3. `psexec -s cmd /c "cd /d <pkg> && Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent"` (SYSTEM-Context; PsExec: https://learn.microsoft.com/en-us/sysinternals/downloads/psexec)
+**Install cycle:**
+1. `.\Invoke-AppDeployToolkit.ps1 -DeploymentType Install -DeployMode Silent` (smoke test)
+2. `.\Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent` (launcher acid test)
+3. `psexec -s cmd /c "cd /d <pkg> && Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent"` (SYSTEM context; PsExec: https://learn.microsoft.com/en-us/sysinternals/downloads/psexec)
 
-**Uninstall-Zyklus (auf gleicher VM, App muss installiert sein):**
+**Uninstall cycle (on the same VM, app must be installed):**
 4. `.\Invoke-AppDeployToolkit.exe -DeploymentType Uninstall -DeployMode Silent`
-5. Verifikations-Checks nach Uninstall:
-   - Detection-Script (siehe Phase 5 Guide) muss `exit 0 + stdout empty` geben (App = nicht installiert)
-   - `Get-Service '<App-Service>' -ErrorAction SilentlyContinue` - leer
-   - `Get-ScheduledTask '<App-Prefix>*' -ErrorAction SilentlyContinue` - leer
-   - Install-Directory: weg (oder nur User-Config-Reste falls Intake-7 so gewuenscht)
-   - Registry unter `HKLM:\SOFTWARE\<Hersteller>\<App>` - weg
-   - Firewall-Rules `Get-NetFirewallRule -DisplayName '<App>*'` - leer
-   - WICHTIG: Nachbarprodukte gleicher Hersteller noch da (nicht versehentlich mitgeloescht)
+5. Verification checks after uninstall:
+   - Detection script (see Phase 5 guide) must return `exit 0 + stdout empty` (app = not installed)
+   - `Get-Service '<App-Service>' -ErrorAction SilentlyContinue` - empty
+   - `Get-ScheduledTask '<App-Prefix>*' -ErrorAction SilentlyContinue` - empty
+   - Install directory: gone (or only user-config leftovers if intake-7 wanted it so)
+   - Registry under `HKLM:\SOFTWARE\<vendor>\<App>` - gone
+   - Firewall rules `Get-NetFirewallRule -DisplayName '<App>*'` - empty
+   - IMPORTANT: neighboring products of the same vendor still present (not accidentally deleted too)
 
-**Repair-Zyklus (VM wieder neu installieren, dann Repair):**
-6. Install wiederholen (Step 1)
+**Repair cycle (reinstall the VM again, then repair):**
+6. Repeat install (step 1)
 7. `.\Invoke-AppDeployToolkit.exe -DeploymentType Repair -DeployMode Silent`
-8. Detection muss danach weiter = installed zeigen; App-Funktionalitaet manuell smoke-testen
+8. Detection must still show = installed afterwards; smoke-test app functionality manually
 
-**Intune-Testgruppe (nach allen drei Zyklen gruen):**
-9. Paket zuweisen als Required → 1 Test-Device → PSADT-Install-Log + AppWorkload.log pruefen
-10. Von Device uninstallen: in Admin Center als "Uninstall" zuweisen ODER User ueber Company Portal deinstallieren → PSADT-Uninstall-Log pruefen
+**Intune test group (after all three cycles are green):**
+9. Assign the package as Required → 1 test device → check the PSADT install log + AppWorkload.log
+10. Uninstall from the device: assign as "Uninstall" in the Admin Center OR have the user uninstall via Company Portal → check the PSADT uninstall log
 
-Pruefen in jedem Intune-Test:
-- `C:\Windows\Logs\Software\<AppName>*PSAppDeployToolkit_Install.log` / `*_Uninstall.log` existiert
-- `Close-ADTSession` mit Exit 0 drin
-- AppWorkload.log zeigt passenden Status (`Installed` / `Uninstalled`)
+Check in every Intune test:
+- `C:\Windows\Logs\Software\<AppName>*PSAppDeployToolkit_Install.log` / `*_Uninstall.log` exists
+- `Close-ADTSession` with exit 0 in it
+- AppWorkload.log shows the matching status (`Installed` / `Uninstalled`)
 
-Nach erfolgreichem Test aller drei Types: Pilot-Gruppe 24-48h, dann Production staged.
+After a successful test of all three types: pilot group 24-48h, then production staged.
 
-## Troubleshooting-Quick-Reference
+## Troubleshooting quick reference
 
-Bei User-Reports in dieser Reihenfolge abklopfen:
+On user reports, check in this order:
 
-| Symptom | Primaerverdacht | Verifikation |
+| Symptom | Primary suspect | Verification |
 |---|---|---|
-| `0x80070001` + keine lokalen PSADT-Logs | Encoding (Em-Dash in "-String") oder Top-Level-Throw | Phase 5 Checks + Anhang A.2 |
-| `0x8000EA68` (60008) + PSADT-Log vorhanden aber leer nach Init | Import-Module / Open-ADTSession wirft | PSADT-Log direkt lesbar, Stack in Anhang A.2 |
-| `0x8000EA61` (60001) + Stacktrace im PSADT-Log | Runtime-Error in Install-ADTDeployment | Stack zeigt Zeile direkt |
-| App haengt "Installing" in Company Portal | IME-State-Cache oder Prozess haengt | Anhang A.2 Aufraeum-Sequenz |
-| `0x80070002` | Launcher findet .ps1 nicht | `-s` beim Packen war falsch |
-| Detection failed after successful install | Detection-Script-Bug (Contract-Verletzung, 32/64-bit-Registry) | Manuell auf Target: `.\Detect-*.ps1; $LASTEXITCODE` |
+| `0x80070001` + no local PSADT logs | Encoding (em-dash in "-string") or top-level throw | Phase 5 checks + appendix A.2 |
+| `0x8000EA68` (60008) + PSADT log present but empty after init | Import-Module / Open-ADTSession throws | PSADT log directly readable, stack in appendix A.2 |
+| `0x8000EA61` (60001) + stacktrace in the PSADT log | Runtime error in Install-ADTDeployment | Stack shows the line directly |
+| App stuck on "Installing" in Company Portal | IME state cache or process hangs | Appendix A.2 cleanup sequence |
+| `0x80070002` | Launcher does not find the .ps1 | `-s` during packaging was wrong |
+| Detection failed after successful install | Detection script bug (contract violation, 32/64-bit registry) | Manually on target: `.\Detect-*.ps1; $LASTEXITCODE` |
 
-HRESULT-Umrechnung: Intune zeigt unbekannte positive Exit-Codes als `0x80070000 + code`. Also `0x80070001` = Exit 1 = Script lief gar nicht. Immer gegenrechnen, nicht von "ERROR_INVALID_FUNCTION"-Text blenden lassen.
+HRESULT conversion: Intune shows unknown positive exit codes as `0x80070000 + code`. So `0x80070001` = exit 1 = script did not run at all. Always recompute, don't be misled by the "ERROR_INVALID_FUNCTION" text.
 
-Logs in dieser Reihenfolge pruefen:
-1. `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\AppWorkload.log` (was IME tatsaechlich gemacht hat + Exit-Code)
-2. `C:\Windows\Logs\Software\<AppName>*PSAppDeployToolkit_Install.log` (PSADT-Session, wenn Init OK war)
-3. `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\IntuneManagementExtension.log` (IME-Service-State)
+Check logs in this order:
+1. `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\AppWorkload.log` (what IME actually did + exit code)
+2. `C:\Windows\Logs\Software\<AppName>*PSAppDeployToolkit_Install.log` (PSADT session, if init was OK)
+3. `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\IntuneManagementExtension.log` (IME service state)
 
-## Anti-Patterns (niemals tun)
+## Anti-patterns (never do)
 
-- v3-Cmdlet-Namen (`Execute-Process`, `Write-Log`, `Show-InstallationWelcome`, ...)
-- Em-Dash/Smart-Quote in Double-Quoted Strings
-- UTF-8-Speichern ohne BOM wenn Non-ASCII drin ist
-- Top-Level-Code ausserhalb try/catch
-- `-o` im `-c` beim IntuneWinAppUtil
-- Return Codes 60001/60008 nicht als Failed mappen
-- Annehmen "laeuft lokal = laeuft in Intune" - Launcher-Acid-Test ist Pflicht
-- Detection gemischt (Custom-Script + File-Rule parallel)
-- Extensions-Funktionen ins Main-Script packen statt in Extensions-Modul
-- Install-Zeit reflexartig auf 120 min - 60 min ist fast immer richtig
-- Fallback-Loesch-Aktionen bei erster negativer Async-Antwort triggern (Services brauchen 30-60s nach msiexec, Retry-Loop bauen)
-- Desktop-Icons anlegen (oder vom Installer angelegte stehen lassen) - nur Startmenue-Eintraege, Desktop bleibt sauber
-- Neuere PSADT-Version nur an der Nummer erkennen und blind uebernehmen - immer Release Notes/Changelog auf geaenderte/deprecated Commands pruefen
+- v3 cmdlet names (`Execute-Process`, `Write-Log`, `Show-InstallationWelcome`, ...)
+- Em-dash/smart quote in double-quoted strings
+- Saving UTF-8 without BOM when non-ASCII is present
+- Top-level code outside try/catch
+- `-o` inside `-c` for IntuneWinAppUtil
+- Not mapping return codes 60001/60008 as Failed
+- Assuming "runs locally = runs in Intune" - the launcher acid test is mandatory
+- Mixed detection (custom script + file rule in parallel)
+- Putting Extensions functions into the main script instead of the Extensions module
+- Writing the dossier in Markdown instead of HTML (the Intune description field has an HTML editor; the dossier is full HTML)
+- Reflexively setting install time to 120 min - 60 min is almost always right
+- Triggering fallback delete actions on the first negative async response (services need 30-60s after msiexec, build a retry loop)
+- Creating desktop icons (or leaving ones created by the installer) - Start Menu entries only, keep the desktop clean
+- Recognizing a newer PSADT version only by its number and adopting it blindly - always check the release notes/changelog for changed/deprecated commands
 
-## Referenz-Nachschlag
+## Reference lookup
 
-Fuer Tiefe zu jedem Thema: `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md`
-- Phase 0.2: Komplette Intake-Fragen-Liste
-- Phase 0.3: Web-Recherche-Pattern
-- Phase 3.1: Encoding-Fix-Details
-- Phase 5: Intune-Config-Felder
-- Anhang A: Error-Codes + Root-Causes
-- Anhang B: Anti-Pattern-Liste
-- Anhang C: Test-Stub-Muster
-- Anhang D: Alle Ressourcen-URLs
-- Anhang E: Finale Deploy-Checkliste
-- Anhang F: Vollstaendiges Intune-Upload-Dossier-Template (alle Felder, alle Tabs)
-- Anhang G: Lessons aus dem Oracle-XE-Projekt
+For depth on every topic: `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md`
+- Phase 0.2: Complete intake question list
+- Phase 0.3: Web research pattern
+- Phase 3.1: Encoding fix details
+- Phase 5: Intune config fields
+- Appendix A: Error codes + root causes
+- Appendix B: Anti-pattern list
+- Appendix C: Test stub patterns
+- Appendix D: All resource URLs
+- Appendix E: Final deploy checklist
+- Appendix F: Complete Intune upload dossier template (all fields, all tabs)
+- Appendix G: Lessons from the Oracle XE project

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,9 +13,9 @@ Diese Skill begleitet den kompletten Lebenszyklus eines **PSADT-v4.x-Intune-Win3
 
 **Verbindliche Konventionen (Details im Block unten):**
 - Fragen an den User IMMER per `AskUserQuestion` (Klick-Optionen), nie als Fliesstext
-- Output-`.intunewin` IMMER zentral nach `c:\Temp\PSADTv4\Output\<App>\`
-- Intune-Dossier IMMER `Intune-Dossier.md`, **Deutsch mit echten Umlauten**; Scripts dagegen **Englisch/ASCII**
-- Author IMMER `Patrick Taubert, PHAT Consulting GmbH`; erste Script-Version `0.1`; Changelog im `.NOTES`-Header Pflicht
+- Output-`.intunewin` IMMER zentral nach `paths.outputRoot`/<App>\ (Default `c:\Temp\PSADTv4\Output\`; tatsaechlicher Wert aus der Config via `Get-PsadtConfig`)
+- Intune-Dossier IMMER `Intune-Dossier.html` (komplett HTML), Sprache aus `language.dossier` (**Default Deutsch mit echten Umlauten**); Scripts dagegen **Englisch/ASCII**
+- Author IMMER aus Config zusammengesetzt (`author.person` + `author.company`; Default `Patrick Taubert, PHAT Consulting GmbH`); erste Script-Version `0.1`; Changelog im `.NOTES`-Header Pflicht
 - App-Logo (PNG, transparent, hochaufloesend) besorgen -> `Assets\` + `Output\<App>\`
 - Nur Startmenue-Eintraege, KEINE Desktop-Icons
 - Alle drei Deployment-Types (Install/Uninstall/Repair) von Anfang an mitbauen und per Acid-Test pruefen
@@ -34,7 +34,7 @@ Du fuehrst den User durch den kompletten Lifecycle eines PSADT-v4.x-Intune-Paket
 ## Konventionen (VERBINDLICH)
 
 - **Sprache - getrennt nach Ziel:**
-  - **Intune-Beschreibung / Dossier (`Intune-Dossier.md`): DEUTSCH mit echten Umlauten** (ä, ö, ü, ß) - das ist Fliesstext fuer Endnutzer im Company Portal, dort sind Umlaute korrekt und erwuenscht (KEIN ae/oe/ue ausschreiben).
+  - **Intune-Beschreibung / Dossier (`Intune-Dossier.html`, komplett HTML): Sprache aus `language.dossier`, Default DEUTSCH mit echten Umlauten** (ä, ö, ü, ß) - das ist Endnutzer-Text fuer das Company Portal, dort sind Umlaute korrekt und erwuenscht (KEIN ae/oe/ue ausschreiben). Die Dossier-Sprache ist ein Config-Wert, keine feste Regel.
   - **In den Scripts selbst (Invoke-AppDeployToolkit.ps1, Extensions, Detection): ALLES auf ENGLISCH** - insb. alle Kommentare. Script-Strings ebenfalls Englisch halten, damit keine Umlaute/Non-ASCII ins PS1 geraten (Encoding-Sauberkeit, siehe Pre-Flight). Umlaute gehoeren NUR in die Dossier-Markdown, nie ins Script.
 - **Author IMMER:** `Patrick Taubert, PHAT Consulting GmbH` (Feld `AppScriptAuthor` im `$adtSession`).
 - **Versionierung des Scripts (`AppScriptVersion` im `$adtSession`):**
@@ -48,6 +48,22 @@ Du fuehrst den User durch den kompletten Lifecycle eines PSADT-v4.x-Intune-Paket
   ```
 
 ## Ablauf (fuehre in dieser Reihenfolge durch)
+
+### 0. Setup (Phase 0 — vor Intake ausfuehren)
+
+Bevor irgendetwas anderes passiert: sicherstellen, dass der Skill konfiguriert ist und die Voraussetzungen vorhanden sind.
+
+1. `pwsh scripts/Get-PsadtConfig.ps1` ausfuehren. Wenn `Exists` true und `Missing` leer ist, direkt weiter zu Intake.
+2. Wenn Config fehlt/unvollstaendig ist, den **Setup-Wizard** fahren — nur die fehlenden Werte abfragen, IMMER per `AskUserQuestion` (Klick-Optionen), empfohlene Option zuerst:
+   - **Pfade**: `paths.packageRoot`, `paths.outputRoot`, `paths.intuneWinAppUtil` (aktuelle Werte als Defaults anbieten).
+   - **Sprachen**: `language.script` (EN), `language.dossier` (DE als Default — aber Config-Wert, nicht fest).
+   - **Author**: `author.person`, `author.company`.
+   - **Intune-Upload** *(fuer eine zukuenftige Version geplant — in dieser Version NICHT aktiv)*: darauf hinweisen, dass es kommt; KEINE Tenant-/Client-ID/Secret abfragen, `intune.uploadEnabled` NICHT setzen. Das fertige `.intunewin` wird vorerst manuell im Admin Center hochgeladen.
+3. Antworten mit `scripts/Set-PsadtConfig.ps1 -Updates @{ ... }` persistieren (in dieser Version ohne `-Secret`).
+4. Voraussetzungen provisionieren (den User nie blockieren):
+   - `pwsh scripts/Get-PsadtModule.ps1` — installiert/aktualisiert PSAppDeployToolkit.
+   - `pwsh scripts/Get-IntuneWinAppUtil.ps1` — laedt/aktualisiert das Content-Prep-Tool nach `tools/`.
+5. Jederzeit per "psadt setup" erneut triggerbar, um einzelne Werte zu aendern.
 
 ### 1. Intake (sofort am Anfang, bevor irgendwas anderes)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ This skill guides the complete lifecycle of a **PSADT v4.x Intune Win32 package*
 - Start Menu entries only, NO desktop icons
 - Build all three deployment types (Install/Uninstall/Repair) from the start and verify them via acid test
 
-Per-topic depth in the reference guide `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md` (appendices A-G).
+Per-topic depth in the reference guide `references/PSADTv4-Deployment-Guide.md` (appendices A-G).
 
 ---
 
@@ -29,7 +29,7 @@ You guide the user through the complete lifecycle of a PSADT v4.x Intune package
 - **Actively drive the conversation** - do not dump a question list; ask targeted blocker questions, research what can be researched, show the user intermediate results
 - **ALWAYS ask questions via `AskUserQuestion` (click options), never as plain free text** - every decision question to the user goes through the `AskUserQuestion` tool with pre-filled, clickable options. Always put the recommended option first and mark it with the suffix "(recommended)". Offer researched defaults as options. The tool automatically adds an "Other" free-text option - so there is no need to build a manual free-text alternative. Plain text is only allowed for intermediate results / status messages, not for questions.
 - **Do not assume Adobe/Oracle as default** - the app to be packaged always comes from the user; examples from the guide are illustration
-- **Reference**: The complete reference guide is at `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md` - point to specific appendices (A-G) there when depth is needed, do NOT dump the whole guide into the conversation
+- **Reference**: The complete reference guide is at `references/PSADTv4-Deployment-Guide.md` - point to specific appendices (A-G) there when depth is needed, do NOT dump the whole guide into the conversation
 
 ## Conventions (BINDING)
 
@@ -427,7 +427,7 @@ Check logs in this order:
 
 ## Reference lookup
 
-For depth on every topic: `c:\Temp\PSADTv4\OracleDB\PSADTv4-Deployment-Guide.md`
+For depth on every topic: `references/PSADTv4-Deployment-Guide.md`
 - Phase 0.2: Complete intake question list
 - Phase 0.3: Web research pattern
 - Phase 3.1: Encoding fix details

--- a/references/PSADTv4-Deployment-Guide.md
+++ b/references/PSADTv4-Deployment-Guide.md
@@ -1,26 +1,26 @@
 # PSADT v4.x Deployment Guide - Intune
 
-Verbindliche End-to-End-Anleitung fuer Intune-Win32-Pakete mit PSADT 4.x. In dieser Reihenfolge abarbeiten. Keine Phasen ueberspringen.
+Mandatory end-to-end guide for Intune Win32 packages with PSADT 4.x. Work through it in this order. Do not skip any phases.
 
-- **Phase 0**: Recherche + Intake (VOR dem ersten Klick)
+- **Phase 0**: Research + Intake (BEFORE the first click)
 - **Phase 1**: Scaffold via `New-ADTTemplate`
-- **Phase 2**: Script-Customizing
-- **Phase 3**: Pre-Flight-Checks (Encoding, Parse, Launcher-Simulation)
-- **Phase 4**: .intunewin bauen
-- **Phase 5**: Intune-App-Konfiguration
-- **Phase 6**: Test-Sequenz
+- **Phase 2**: Script customizing
+- **Phase 3**: Pre-flight checks (encoding, parse, launcher simulation)
+- **Phase 4**: Build the .intunewin
+- **Phase 5**: Intune app configuration
+- **Phase 6**: Test sequence
 - **Phase 7**: Rollout
-- **Anhaenge**: A Error-Ref / B Anti-Patterns / C Stub-Tricks / D Ressourcen / E Final-Checklist / F Intune-Upload-Dossier / G Lessons Learned
+- **Appendices**: A Error Reference / B Anti-Patterns / C Stub Tricks / D Resources / E Final Checklist / F Intune Upload Dossier / G Lessons Learned
 
 ---
 
-## Phase 0: Recherche + Intake (NICHT ueberspringen)
+## Phase 0: Research + Intake (DO NOT skip)
 
-### 0.1 Aktuelle PSADT-Version pruefen
+### 0.1 Check the current PSADT version
 
-Bevor irgendein Paket gebaut wird: ist das lokale PSADT-Modul noch aktuell? Breaking Changes zwischen Minor-Versionen kommen vor (4.0.x -> 4.1.x Param-Umbenennungen).
+Before any package is built: is the local PSADT module still up to date? Breaking changes between minor versions do happen (4.0.x -> 4.1.x parameter renames).
 
-**Check-Befehle (online + lokal):**
+**Check commands (online + local):**
 
 ```powershell
 # Lokale Modulversion
@@ -32,82 +32,82 @@ $rel = Invoke-RestMethod 'https://api.github.com/repos/PSAppDeployToolkit/PSAppD
 $rel.body -split "`n" | Select-Object -First 40   # Changelog-Auszug
 ```
 
-**Docs-Stand pruefen:**
-- Release-Notes: https://psappdeploytoolkit.com/docs/getting-started/release-notes
-- Migrations-Guide (v3 -> v4): https://psappdeploytoolkit.com/docs/migration/migrate-from-v3
-- Reference-Index (alle Cmdlets): https://psappdeploytoolkit.com/docs/reference
-- Blog (Releases + Community Updates): https://psappdeploytoolkit.com/blog
-- Discourse (Forum): https://discourse.psappdeploytoolkit.com/latest
+**Check the documentation status:**
+- Release notes: https://psappdeploytoolkit.com/docs/getting-started/release-notes
+- Migration guide (v3 -> v4): https://psappdeploytoolkit.com/docs/migration/migrate-from-v3
+- Reference index (all cmdlets): https://psappdeploytoolkit.com/docs/reference
+- Blog (releases + community updates): https://psappdeploytoolkit.com/blog
+- Discourse (forum): https://discourse.psappdeploytoolkit.com/latest
 
-**Entscheidung:**
-- Lokal < Latest Minor: Modul aktualisieren (`Update-Module PSAppDeployToolkit -Force` oder aus GitHub-Release entpacken) BEVOR neues Paket gebaut wird
-- Lokal == Latest: weiter
-- Lokal > Latest (Beta): auf stable downgraden, keine Beta in Prod
+**Decision:**
+- Local < latest minor: update the module (`Update-Module PSAppDeployToolkit -Force` or extract from the GitHub release) BEFORE building a new package
+- Local == latest: continue
+- Local > latest (beta): downgrade to stable, no beta in production
 
-Die Modul-Version muss im Paket `<pkg>\PSAppDeployToolkit\PSAppDeployToolkit.psd1` `ModuleVersion = '<VER>'` exakt zu dem passen, was im Script `$adtSession.DeployAppScriptVersion = '<VER>'` steht UND zur `Invoke-AppDeployToolkit.exe`-Build-Version (RightClick-Properties-Details).
+The module version in the package `<pkg>\PSAppDeployToolkit\PSAppDeployToolkit.psd1` `ModuleVersion = '<VER>'` must exactly match what the script declares in `$adtSession.DeployAppScriptVersion = '<VER>'` AND the `Invoke-AppDeployToolkit.exe` build version (right-click properties, details).
 
-### 0.2 Intake-Fragen zur App (bevor auch nur eine Zeile Code entsteht)
+### 0.2 Intake questions about the app (before a single line of code exists)
 
-Ohne Antworten zu diesen Punkten wird das Paket Mist. Mit Stakeholder / User klaeren:
+Without answers to these points the package will be junk. Clarify with the stakeholder / user:
 
-**App-Identitaet:**
-- Exakter Produktname und Hersteller (wie im Company Portal stehen soll)
-- Version (Marketing-Version + Dateiversion im MSI / Setup.exe)
-- Sprache (EN, DE, Multi?)
-- Architektur (x86 / x64 / ARM64 / Universal)
-- Lizenzmodell (Freeware, Pro, Enterprise, Named User, Device, Subscription? Lizenzkey noetig? Activation-Server?)
+**App identity:**
+- Exact product name and vendor (as it should appear in the Company Portal)
+- Version (marketing version + file version in the MSI / Setup.exe)
+- Language (EN, DE, Multi?)
+- Architecture (x86 / x64 / ARM64 / Universal)
+- Licensing model (Freeware, Pro, Enterprise, Named User, Device, Subscription? License key needed? Activation server?)
 
 **Installer:**
-- Quell-Medium: MSI, EXE-Wrapper (um MSI), InstallShield, NSIS, AppX/MSIX, Squirrel, selbstgebautes?
-- Download-URL des offiziellen Installers (fuer Reproduzierbarkeit) + Hash
-- Silent-Install-Switches bekannt? (siehe 0.3)
-- Uninstall-Methode: MSI-ProductCode, Uninstallstring in Registry, Custom-Uninstaller?
-- Repair-Unterstuetzung?
-- Reboot-Verhalten (erfordert, empfiehlt, nie)
-- Abhaengigkeiten: .NET, VC++ Redist, Java, Edge-WebView2, PowerShell-Version?
+- Source medium: MSI, EXE wrapper (around an MSI), InstallShield, NSIS, AppX/MSIX, Squirrel, self-built?
+- Download URL of the official installer (for reproducibility) + hash
+- Silent install switches known? (see 0.3)
+- Uninstall method: MSI product code, uninstall string in the registry, custom uninstaller?
+- Repair support?
+- Reboot behavior (requires, recommends, never)
+- Dependencies: .NET, VC++ Redist, Java, Edge WebView2, PowerShell version?
 
-**Ziel-Umgebung:**
-- Intune-Zielgruppe (User- oder Device-based? AAD-Gruppe, Filter?)
-- Install-Context: System (klassisch), User (selten), Available + Required?
-- Min-OS-Version, Architecture-Filter
-- Koexistenz mit Vorversionen: Upgrade-in-Place, Side-by-Side, Force-Uninstall-Altversionen?
-- Conflicting-Apps: gibt's konkurrierende Produkte die raus muessen?
-- Roaming-Profile / FSLogix / Nicht-persistente-VDI?
+**Target environment:**
+- Intune target audience (user- or device-based? AAD group, filter?)
+- Install context: System (classic), User (rare), Available + Required?
+- Minimum OS version, architecture filter
+- Coexistence with previous versions: in-place upgrade, side-by-side, force-uninstall old versions?
+- Conflicting apps: are there competing products that have to go?
+- Roaming profiles / FSLogix / non-persistent VDI?
 
-**Laufzeitverhalten:**
-- Prozesse die geschlossen werden muessen (fuer `AppProcessesToClose` in `$adtSession`)
-- Sichtbare UI waehrend Install (Silent vs. NonInteractive)? 
-- User-Benachrichtigungen gewuenscht (Welcome-Dialog, Defer-Button, Countdown)?
-- Erforderliche Umgebungsvariablen / Registry-Policies
-- Firewall-Regeln / Service-Konten
+**Runtime behavior:**
+- Processes that have to be closed (for `AppProcessesToClose` in `$adtSession`)
+- Visible UI during install (Silent vs. NonInteractive)?
+- User notifications desired (welcome dialog, defer button, countdown)?
+- Required environment variables / registry policies
+- Firewall rules / service accounts
 
-**Konfiguration / Customizing:**
-- Default-Settings die ueberschrieben werden sollen (Startup-Behavior, Telemetrie-Opt-Out, Updater-Abschaltung, Default-Ordner)
-- Registry-Keys / ADMX / XML / JSON zum Injizieren
-- Files-to-Copy in AppData / ProgramData
-- Shortcuts (Desktop, StartMenu) platzieren oder entfernen?
+**Configuration / customizing:**
+- Default settings that should be overridden (startup behavior, telemetry opt-out, updater disablement, default folder)
+- Registry keys / ADMX / XML / JSON to inject
+- Files to copy into AppData / ProgramData
+- Shortcuts (Desktop, Start Menu) to place or remove?
 
 **Detection:**
-- Wie eindeutig nachweisen dass installiert? MSI-ProductCode ist meist genug; bei EXE-Installern oft File-Version + Registry.
-- Zwingend funktionaler Test (z.B. "DB erreichbar", "Service laeuft") oder reicht Presence-Check?
+- How do you prove unambiguously that it is installed? The MSI product code is usually enough; for EXE installers often file version + registry.
+- A mandatory functional test (e.g. "DB reachable", "service running") or is a presence check sufficient?
 
-**Uninstall / Cleanup:**
-- Was MUSS weggeraeumt werden bei Uninstall (User-Daten behalten? Registry-Leichen entfernen?)
-- Was DARF NICHT geloescht werden (Shared-Komponenten, User-Templates)?
-- Soll Uninstall auch Vorversionen killen oder nur die selbst installierte?
+**Uninstall / cleanup:**
+- What MUST be cleaned up on uninstall (keep user data? remove registry leftovers?)
+- What MUST NOT be deleted (shared components, user templates)?
+- Should uninstall also kill previous versions or only the one it installed itself?
 
-**Sicherheit:**
-- Credentials im Installer noetig (Service-Account, API-Key, Cert)? Wie werden die an den Install uebergeben ohne im Log/Filesystem zu landen?
-- PII / GDPR-relevante Konfiguration?
-- Signaturprufung erwartet?
+**Security:**
+- Credentials needed in the installer (service account, API key, cert)? How are they passed to the install without ending up in the log/filesystem?
+- PII / GDPR-relevant configuration?
+- Signature check expected?
 
-Diese Liste als Intake-Formular nehmen; was offen bleibt = Risiko im Deploy.
+Use this list as an intake form; whatever stays open = risk in the deployment.
 
-### 0.3 Web-Recherche zum konkreten Installer
+### 0.3 Web research on the specific installer
 
-Pro App recherchieren - ohne diese Antworten kein erfolgreiches Silent-Install:
+Research per app - without these answers there is no successful silent install:
 
-**Pflicht-Such-Queries (Beispiele):**
+**Mandatory search queries (examples):**
 ```
 "<AppName>" "<Version>" silent install command line
 "<AppName>" msi transform mst enterprise deployment
@@ -116,49 +116,49 @@ Pro App recherchieren - ohne diese Antworten kein erfolgreiches Silent-Install:
 "<AppName>" known issues intune win32
 ```
 
-**Offizielle Quellen immer zuerst:**
-- Hersteller-Admin-Guide / Enterprise-Deployment-Guide (Adobe Admin Console, Autodesk Enterprise, Microsoft Docs, ...)
-- Release-Notes fuer die spezifische Version
-- Knowledge Base / Support Forum des Herstellers
+**Official sources always first:**
+- Vendor admin guide / enterprise deployment guide (Adobe Admin Console, Autodesk Enterprise, Microsoft Docs, ...)
+- Release notes for the specific version
+- Knowledge base / support forum of the vendor
 
-**Community-Quellen (zur Validierung):**
-- `silentinstallhq.com` - Silent-Switches fuer viele Apps
-- `deploymentresearch.com` - Tim Mangans Archiv
+**Community sources (for validation):**
+- `silentinstallhq.com` - silent switches for many apps
+- `deploymentresearch.com` - Tim Mangan's archive
 - PSADT Discourse: https://discourse.psappdeploytoolkit.com/search
-- `/r/SCCM`, `/r/Intune` auf Reddit
-- GitHub: Suche nach `<appname> intune win32` oder `<appname> PSADT`
+- `/r/SCCM`, `/r/Intune` on Reddit
+- GitHub: search for `<appname> intune win32` or `<appname> PSADT`
 
-**Minimal-Ergebnis dokumentieren:**
+**Document the minimal result:**
 
-| Frage | Antwort | Quelle |
+| Question | Answer | Source |
 |---|---|---|
-| Silent-Install-CMD | `<...>` | |
-| Silent-Uninstall-CMD | `<...>` | |
-| Bekannte Exit-Codes (Erfolg, Reboot, Fehler) | `0, 3010, ...` | |
-| Logfile-Pfad des Installers | `<...>` | |
-| Dependency-Installer (wenn separat) | `<...>` | |
-| Bekannte Intune-Stolpersteine | `<...>` | |
-| Known-Post-Install-Config (Registry / XML) | `<...>` | |
+| Silent install CMD | `<...>` | |
+| Silent uninstall CMD | `<...>` | |
+| Known exit codes (success, reboot, error) | `0, 3010, ...` | |
+| Installer log file path | `<...>` | |
+| Dependency installer (if separate) | `<...>` | |
+| Known Intune pitfalls | `<...>` | |
+| Known post-install config (registry / XML) | `<...>` | |
 
-Ohne diese Tabelle ausgefuellt: **nicht packen**.
+Without this table filled in: **do not package**.
 
-**Beispiel (Adobe Acrobat Pro):**
-- Admin-Guide: https://www.adobe.com/devnet-docs/acrobatetk/
-- Customization Wizard (MST bauen): https://www.adobe.com/devnet-docs/acrobatetk/tools/Wizard/index.html
-- Package via Adobe Admin Console (Creative Cloud): offizieller Weg fuer neuere Versionen
+**Example (Adobe Acrobat Pro):**
+- Admin guide: https://www.adobe.com/devnet-docs/acrobatetk/
+- Customization Wizard (build the MST): https://www.adobe.com/devnet-docs/acrobatetk/tools/Wizard/index.html
+- Package via Adobe Admin Console (Creative Cloud): the official path for newer versions
 
-**Beispiel (Oracle Database XE):**
-- Doku: https://docs.oracle.com/en/database/oracle/oracle-database/21/xeinw/
-- Silent-Install: `setup.exe /s /f1"XEInstall.rsp"` + Response-File
-- Bekannter Stolperstein: `svc_oracle` muss VOR Install existieren (deshalb im Script der Service-Account-Create)
+**Example (Oracle Database XE):**
+- Docs: https://docs.oracle.com/en/database/oracle/oracle-database/21/xeinw/
+- Silent install: `setup.exe /s /f1"XEInstall.rsp"` + response file
+- Known pitfall: `svc_oracle` must exist BEFORE install (which is why the script creates the service account)
 
 ---
 
 ## Phase 1: Scaffold via `New-ADTTemplate`
 
-Nicht manuell Ordner anlegen. Der offizielle Cmdlet baut die korrekte Struktur.
+Do not create folders manually. The official cmdlet builds the correct structure.
 
-### 1.1 Modul laden, Scaffold erzeugen
+### 1.1 Load the module, generate the scaffold
 
 ```powershell
 # Einmalig - oder wenn Version veraltet
@@ -168,17 +168,17 @@ Install-Module PSAppDeployToolkit -Scope CurrentUser -Force
 Import-Module PSAppDeployToolkit
 ```
 
-Werte kommen aus dem Intake aus Phase 0.2 - ersetze `<...>` durch die TATSAECHLICHEN Werte der App, die gerade paketiert wird.
+The values come from the intake in Phase 0.2 - replace `<...>` with the ACTUAL values of the app currently being packaged.
 
-**Basic-Scaffold (nur Destination + Name):**
+**Basic scaffold (only destination + name):**
 ```powershell
 New-ADTTemplate -Destination '<Root-Ordner>' -Name '<AppName>'
 # z.B. New-ADTTemplate -Destination 'C:\Temp\PSADTv4' -Name 'FooBar 10'
 ```
 
-Erzeugt `<Root-Ordner>\<AppName>\` mit kompletter v4-Struktur. Standard ist `-Version 4` (aktueller v4-Stil). `-Version 3` gibt das v3-Kompatibilitaets-Template (braucht man 2026 nicht mehr).
+Creates `<Root-Ordner>\<AppName>\` with the complete v4 structure. The default is `-Version 4` (current v4 style). `-Version 3` gives the v3 compatibility template (you no longer need that in 2026).
 
-**Extended-Scaffold (vorbefuellt mit App-Metadaten, Werte aus Phase 0.2):**
+**Extended scaffold (pre-populated with app metadata, values from Phase 0.2):**
 ```powershell
 New-ADTTemplate -Destination '<Root-Ordner>' `
     -Name '<AppName>' `
@@ -193,11 +193,11 @@ New-ADTTemplate -Destination '<Root-Ordner>' `
     -AppScriptAuthor '<Vorname Nachname>'
 ```
 
-Die Werte landen direkt als `$adtSession = @{...}` im generierten `Invoke-AppDeployToolkit.ps1`. Weniger manuelles Editieren = weniger Tippfehler.
+The values land directly as `$adtSession = @{...}` in the generated `Invoke-AppDeployToolkit.ps1`. Less manual editing = fewer typos.
 
-> Die `Adobe Acrobat Pro`- und `Oracle XE`-Referenzen weiter unten im Dokument sind ausschliesslich Illustration - bei jedem neuen Paket wird hier die ZU PAKETIERENDE App eingesetzt, nicht Adobe oder Oracle.
+> The `Adobe Acrobat Pro` and `Oracle XE` references further down in this document are illustration only - for every new package the app TO BE PACKAGED is inserted here, not Adobe or Oracle.
 
-### 1.2 Was im Scaffold entsteht
+### 1.2 What the scaffold produces
 
 ```
 <Destination>\<Name>\
@@ -212,7 +212,7 @@ Die Werte landen direkt als `$adtSession = @{...}` im generierten `Invoke-AppDep
   Strings\                             # Lokalisierungs-Overrides (optional)
 ```
 
-### 1.3 Erste Verifizierung des Scaffolds
+### 1.3 First verification of the scaffold
 
 ```powershell
 $pkg = '<Scaffold-Pfad>'   # z.B. 'C:\Temp\PSADTv4\<AppName>'
@@ -222,20 +222,20 @@ $pkg = '<Scaffold-Pfad>'   # z.B. 'C:\Temp\PSADTv4\<AppName>'
 Select-String "$pkg\Invoke-AppDeployToolkit.ps1" -Pattern 'DeployAppScriptVersion' -List | Select-Object Line
 ```
 
-Beides muss matchen (typisch `4.1.8`). Wenn divergent -> Modul neu installieren + neu scaffolden.
+Both must match (typically `4.1.8`). If they diverge -> reinstall the module + scaffold again.
 
 ---
 
-## Phase 2: Script-Customizing
+## Phase 2: Script customizing
 
-### 2.1 Installer in `Files\` legen
+### 2.1 Put the installer in `Files\`
 
-Alles was `setup.exe`, `*.msi`, `*.mst`, Response-Files, Runtime-Assets ist, landet unter `<pkg>\Files\`.
-Im Script dann `$adtSession.DirFiles` als Root.
+Everything that is `setup.exe`, `*.msi`, `*.mst`, response files, runtime assets lands under `<pkg>\Files\`.
+In the script then use `$adtSession.DirFiles` as the root.
 
-### 2.2 `$adtSession`-Metadaten finalisieren
+### 2.2 Finalize the `$adtSession` metadata
 
-Im `Invoke-AppDeployToolkit.ps1` den Hashtable pruefen (siehe 0.2 Intake fuer die Werte):
+In `Invoke-AppDeployToolkit.ps1` check the hashtable (see 0.2 Intake for the values):
 
 ```powershell
 $adtSession = @{
@@ -260,11 +260,11 @@ $adtSession = @{
 }
 ```
 
-### 2.3 Install/Uninstall/Repair-Hooks fuellen
+### 2.3 Fill the Install/Uninstall/Repair hooks
 
-Das Scaffold hat drei leere Funktionen: `Install-ADTDeployment`, `Uninstall-ADTDeployment`, `Repair-ADTDeployment`. Jede hat Pre/Install/Post-MARK-Abschnitte.
+The scaffold has three empty functions: `Install-ADTDeployment`, `Uninstall-ADTDeployment`, `Repair-ADTDeployment`. Each has Pre/Install/Post MARK sections.
 
-**Minimal-Pattern fuer MSI:**
+**Minimal pattern for MSI:**
 ```powershell
 function Install-ADTDeployment {
     $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
@@ -279,16 +279,16 @@ function Install-ADTDeployment {
 }
 ```
 
-**Pattern fuer EXE-Wrapper:**
+**Pattern for an EXE wrapper:**
 ```powershell
 Start-ADTProcess -FilePath "$($adtSession.DirFiles)\setup.exe" -ArgumentList '/silent /allusers=1 /log="C:\Windows\Logs\Software\install.log"' -SuccessExitCodes @(0, 3010, 1641) -WaitForMsiExec
 ```
 
-Immer `-SuccessExitCodes` mitgeben - sonst wirft Start-ADTProcess bei allem != 0.
+Always pass `-SuccessExitCodes` - otherwise Start-ADTProcess throws on anything != 0.
 
-### 2.4 Extensions-Modul fuer Helper-Funktionen
+### 2.4 Extensions module for helper functions
 
-Custom-Helpers gehoeren in `<pkg>\PSAppDeployToolkit.Extensions\PSAppDeployToolkit.Extensions.psm1` - NICHT direkt ins Main-Script. Gruende: Wiederverwendung, saubere Namespaces, Main-Script bleibt lesbar.
+Custom helpers belong in `<pkg>\PSAppDeployToolkit.Extensions\PSAppDeployToolkit.Extensions.psm1` - NOT directly in the main script. Reasons: reuse, clean namespaces, the main script stays readable.
 
 ```powershell
 # PSAppDeployToolkit.Extensions.psm1
@@ -297,17 +297,17 @@ function Disable-AppUpdater    { ... }
 Export-ModuleMember -Function Set-CompanyBranding, Disable-AppUpdater
 ```
 
-Das Main-Script lädt die Extensions automatisch (der Block `Get-ChildItem ... -match 'PSAppDeployToolkit\..+$'` am Ende von `Invoke-AppDeployToolkit.ps1`).
+The main script loads the extensions automatically (the block `Get-ChildItem ... -match 'PSAppDeployToolkit\..+$'` at the end of `Invoke-AppDeployToolkit.ps1`).
 
 ---
 
-## Phase 3: Pre-Flight-Checks
+## Phase 3: Pre-flight checks
 
-Alles aus dieser Phase ausfuehren. Jeder Fehlschlag = NICHT weiter.
+Run everything in this phase. Each failure = DO NOT continue.
 
-### 3.1 Encoding-Check (UTF-8 mit BOM oder ASCII-only)
+### 3.1 Encoding check (UTF-8 with BOM or ASCII-only)
 
-PowerShell 5.1 liest .ps1 ohne BOM als Windows-1252. UTF-8-Multibytes (Em-Dash `—`, Pfeil `→`, Umlaute, typografische Quotes, Ellipsis `…`) zerfallen. In Double-Quoted Strings **schliesst** ein falsch interpretierter Em-Dash den String vorzeitig (UTF-8 `E2 80 94` -> CP1252 `â€"`, letztes Byte = `"`). Parse-Error. Script laeuft NIE. Intune zeigt `0x80070001`, keine lokalen Logs.
+PowerShell 5.1 reads a .ps1 without a BOM as Windows-1252. UTF-8 multibytes (em-dash `—`, arrow `→`, umlauts, typographic quotes, ellipsis `…`) fall apart. In double-quoted strings a misinterpreted em-dash **closes** the string prematurely (UTF-8 `E2 80 94` -> CP1252 `â€"`, last byte = `"`). Parse error. The script NEVER runs. Intune shows `0x80070001`, no local logs.
 
 ```powershell
 $s = '<pfad-zur-ps1>'
@@ -318,9 +318,9 @@ $nonAscii = [regex]::Matches($text, '[^\x00-\x7F]') | ForEach-Object { $_.Value 
 "HasBOM=$hasBom NonAscii=$($nonAscii -join ' ') Count=$(([regex]::Matches($text,'[^\x00-\x7F]')).Count)"
 ```
 
-Akzeptanzkriterium: `HasBOM=True` ODER `Count=0`. Beides = Defense-in-Depth.
+Acceptance criterion: `HasBOM=True` OR `Count=0`. Both = defense in depth.
 
-Fix, wenn nicht:
+Fix, if not:
 ```powershell
 $text = [System.IO.File]::ReadAllText($s, [System.Text.Encoding]::UTF8)
 $text = $text -replace [char]0x2014, '-'      # em-dash
@@ -334,7 +334,7 @@ $text = $text -replace [char]0x2026, '...'    # ellipsis
 [System.IO.File]::WriteAllText($s, $text, [System.Text.UTF8Encoding]::new($true))
 ```
 
-### 3.2 Parse-Check
+### 3.2 Parse check
 
 ```powershell
 $errs = $null
@@ -342,11 +342,11 @@ $null = [System.Management.Automation.Language.Parser]::ParseFile($s, [ref]$null
 if ($errs) { $errs | Select Message,@{N='L';E={$_.Extent.StartLineNumber}} } else { 'PARSE_OK' }
 ```
 
-WICHTIG: `Parser::ParseFile` detektiert UTF-8-ohne-BOM korrekt und meldet oft `PARSE_OK` obwohl powershell.exe via Launcher trotzdem knallt. Der 3.3-Test ist der ECHTE Gate.
+IMPORTANT: `Parser::ParseFile` detects UTF-8-without-BOM correctly and often reports `PARSE_OK` even though powershell.exe via the launcher still blows up. The 3.3 test is the REAL gate.
 
-### 3.3 Launcher-Simulation (Acid-Test)
+### 3.3 Launcher simulation (acid test)
 
-Der `Invoke-AppDeployToolkit.exe`-Launcher ruft PS5.1 mit `-Command "try { & 'script.ps1' ... } catch { throw }; exit $Global:LASTEXITCODE"` auf. Genau das replizieren:
+The `Invoke-AppDeployToolkit.exe` launcher calls PS5.1 with `-Command "try { & 'script.ps1' ... } catch { throw }; exit $Global:LASTEXITCODE"`. Replicate exactly that:
 
 ```powershell
 Start-Process powershell.exe -ArgumentList `
@@ -356,13 +356,13 @@ Start-Process powershell.exe -ArgumentList `
 Get-Content stderr.log
 ```
 
-Parse-Errors im stderr trotz gruenem 3.2 = Encoding-Bug, zurueck zu 3.1.
+Parse errors in stderr despite a green 3.2 = encoding bug, back to 3.1.
 
-Bei Scripten die echte Installer anstossen: Install-ADTDeployment-Body stubben (siehe Anhang C).
+For scripts that trigger real installers: stub the Install-ADTDeployment body (see Appendix C).
 
-### 3.4 Param-Block vs. v4-Template
+### 3.4 Param block vs. v4 template
 
-Param-Block im Main-Script muss zu `<pkg>\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1` passen. Stand 4.1.8:
+The param block in the main script must match `<pkg>\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1`. As of 4.1.8:
 
 ```powershell
 [CmdletBinding()]
@@ -375,13 +375,13 @@ param (
 )
 ```
 
-NICHT: `$AllowRebootPassThru` (v3-Denken). Eigene Parameter (z.B. `$DbPassword`) hinten anhaengen, VOR `Open-ADTSession` aus `$iadtParams` entfernen.
+NOT: `$AllowRebootPassThru` (v3 thinking). Append your own parameters (e.g. `$DbPassword`) at the end, and remove them from `$iadtParams` BEFORE `Open-ADTSession`.
 
-### 3.5 v3-Cmdlet-Rueckstaende
+### 3.5 Leftover v3 cmdlets
 
-Verboten im Code:
+Forbidden in the code:
 
-| v3 (weg) | v4 (richtig) |
+| v3 (gone) | v4 (correct) |
 |---|---|
 | `Execute-Process` | `Start-ADTProcess` |
 | `Execute-MSI` | `Start-ADTMsiProcess` |
@@ -405,9 +405,9 @@ $t = [System.IO.File]::ReadAllText($s)
 foreach ($fn in $v3) { $m = [regex]::Matches($t, "\b$fn\b"); if ($m.Count) { "V3_FOUND: $fn ($($m.Count)x)" } }
 ```
 
-### 3.6 Top-Level-Statements ausserhalb try/catch
+### 3.6 Top-level statements outside try/catch
 
-Alles was NICHT in einem try/catch ist und wirft = exit 1 = kein Log. Top-Level erlaubt nur Attribute, Param-Block, simple `$var = @{...}`, Preference-Variablen, `Set-StrictMode`, `try/catch`.
+Anything that is NOT inside a try/catch and throws = exit 1 = no log. At top level only the following are allowed: attributes, the param block, simple `$var = @{...}`, preference variables, `Set-StrictMode`, `try/catch`.
 
 ```powershell
 $ast = [System.Management.Automation.Language.Parser]::ParseFile($s, [ref]$null, [ref]$null)
@@ -415,17 +415,17 @@ $ast.EndBlock.Statements | Where-Object { $_ -isnot [System.Management.Automatio
     ForEach-Object { "L$($_.Extent.StartLineNumber): $($_.GetType().Name)" }
 ```
 
-Alles was kein `AssignmentStatementAst` / `PipelineAst` (fuer Set-StrictMode) / `TryStatementAst` ist = pruefen.
+Anything that is not an `AssignmentStatementAst` / `PipelineAst` (for Set-StrictMode) / `TryStatementAst` = check it.
 
 ---
 
-## Phase 4: .intunewin bauen
+## Phase 4: Build the .intunewin
 
-### 4.1 IntuneWinAppUtil holen
+### 4.1 Get IntuneWinAppUtil
 
-Microsoft's offizielles Packaging-Tool. Immer die aktuelle Version:
+Microsoft's official packaging tool. Always the current version:
 - GitHub: https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool
-- Direct-Download (releases/latest): `https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/releases/latest`
+- Direct download (releases/latest): `https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/releases/latest`
 
 ```powershell
 $tool = 'C:\Tools\IntuneWinAppUtil.exe'
@@ -438,7 +438,7 @@ if (-not (Test-Path $tool)) {
 & $tool -v
 ```
 
-### 4.2 Packen
+### 4.2 Package
 
 ```powershell
 $src = '<Paketordner aus Phase 1>'                  # z.B. 'C:\Temp\PSADTv4\<AppName>'
@@ -449,201 +449,201 @@ New-Item $out -ItemType Directory -Force | Out-Null
 & $tool -c $src -s $setupFile -o $out -q
 ```
 
-Parameter:
-- `-c <srcDir>` - der Paketordner mit .exe + .ps1 + PSAppDeployToolkit + Files
-- `-s <setupFile>` - relativer Pfad (zu `-c`) zur Entry-.exe. IMMER `Invoke-AppDeployToolkit.exe`, **nicht** `.ps1` (Launcher braucht WDAC-Kompatibilitaet und 64-bit-PS-Bootstrap)
-- `-o <outDir>` - Ausgabeordner fuer die .intunewin - **nicht** in `-c` rein, sonst packt ein Rebuild die alte .intunewin mit ein (nested, doppelter Speicher)
-- `-q` - quiet, keine Eingabe-Prompts
-- `-a <catalogFolder>` - optional, Katalogdateien fuer WDAC-signierte Umgebungen
-- `-e` - verschluesselungs-Output-Info (interessant fuer Tooling, nicht fuer Intune)
+Parameters:
+- `-c <srcDir>` - the package folder with .exe + .ps1 + PSAppDeployToolkit + Files
+- `-s <setupFile>` - relative path (to `-c`) to the entry .exe. ALWAYS `Invoke-AppDeployToolkit.exe`, **not** `.ps1` (the launcher needs WDAC compatibility and a 64-bit PS bootstrap)
+- `-o <outDir>` - output folder for the .intunewin - **not** inside `-c`, otherwise a rebuild packs the old .intunewin in too (nested, double storage)
+- `-q` - quiet, no input prompts
+- `-a <catalogFolder>` - optional, catalog files for WDAC-signed environments
+- `-e` - encryption output info (interesting for tooling, not for Intune)
 
-Ergebnis-Plausibilitaet:
+Result plausibility:
 ```powershell
 $iw = Get-ChildItem "$out\*.intunewin" | Select-Object -First 1
 "Size: $([Math]::Round($iw.Length / 1MB, 1)) MB"
 "Approx Files/-Size: $([Math]::Round(((Get-ChildItem "$src\Files" -Recurse -File | Measure-Object -Property Length -Sum).Sum) / 1MB, 1)) MB"
 ```
 
-Drastisch groesser als Files + 20-50 MB Toolkit = nested .intunewin, `-o` war im `-c`, neu packen mit externem Output.
+Drastically larger than Files + 20-50 MB toolkit = nested .intunewin, `-o` was inside `-c`, repackage with an external output.
 
-### 4.3 Entpackbarkeit pruefen (offline)
+### 4.3 Check extractability (offline)
 
-Die .intunewin ist eine AES-verschluesselte ZIP. Ohne Intune nicht entpackbar, aber das Outer-ZIP hat eine Metadata-XML die unverschluesselt zugaenglich ist:
+The .intunewin is an AES-encrypted ZIP. Not extractable without Intune, but the outer ZIP has a metadata XML that is accessible unencrypted:
 
 ```powershell
 Expand-Archive -Path $iw.FullName -DestinationPath "$env:TEMP\iw-inspect" -Force
 Get-Content "$env:TEMP\iw-inspect\IntuneWinPackage\Metadata\Detection.xml"
 ```
 
-Die XML muss `<SetupFile>Invoke-AppDeployToolkit.exe</SetupFile>` enthalten. Wenn da was anderes steht: falscher `-s` beim Packen.
+The XML must contain `<SetupFile>Invoke-AppDeployToolkit.exe</SetupFile>`. If something else is there: wrong `-s` during packaging.
 
 ---
 
-## Phase 5: Intune-App-Konfiguration
+## Phase 5: Intune app configuration
 
 ### 5.1 App Information
-- Name / Version / Publisher: matched zu `$adtSession.AppName / AppVersion / AppVendor`
-- Description: Markdown-faehig, erster Absatz standalone lesbar (~200 Zeichen sind die Kurzvorschau im Company Portal)
-- Category: semantisch korrekt waehlen (Development, Productivity, ...)
+- Name / Version / Publisher: matches `$adtSession.AppName / AppVersion / AppVendor`
+- Description: Markdown-capable, the first paragraph readable standalone (~200 characters are the short preview in the Company Portal)
+- Category: choose it semantically correct (Development, Productivity, ...)
 - Logo: `<pkg>\Assets\AppIcon.png`, 256x256 PNG transparent
 
 ### 5.2 Program
 - **Install command**: `Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent`
-- **Uninstall command**: `Invoke-AppDeployToolkit.exe -DeploymentType Uninstall -DeployMode Silent` (Case egal, ValidateSet ist case-insensitive)
-- **Install behavior**: `System` (Default; SYSTEM-Context ist richtig fuer Win32-Apps)
-- **Device restart behavior**: 
-  - `App install may force a device restart` - wenn Installer 1641 liefern kann
-  - `Determine behavior based on return codes` - default, greift auf Return-Codes-Mapping zurueck
-- **Allow available uninstall**: Yes (erlaubt User Uninstall ueber Company Portal)
+- **Uninstall command**: `Invoke-AppDeployToolkit.exe -DeploymentType Uninstall -DeployMode Silent` (case does not matter, the ValidateSet is case-insensitive)
+- **Install behavior**: `System` (default; the SYSTEM context is correct for Win32 apps)
+- **Device restart behavior**:
+  - `App install may force a device restart` - when the installer can return 1641
+  - `Determine behavior based on return codes` - default, falls back to the return-code mapping
+- **Allow available uninstall**: Yes (lets the user uninstall via the Company Portal)
 
-### 5.3 Return codes (kritisch, nie auslassen)
+### 5.3 Return codes (critical, never omit)
 
-Pflicht-Mapping, sonst zeigt Intune unbekannte Exit-Codes als `0x80070000 + code`:
+Mandatory mapping, otherwise Intune shows unknown exit codes as `0x80070000 + code`:
 
-| Code | Type | Grund |
+| Code | Type | Reason |
 |---:|---|---|
 | 0 | Success | OK |
-| 1707 | Success | MSI-Success-Alternative |
-| 3010 | Soft reboot | Reboot empfohlen |
-| 1641 | Hard reboot | Reboot erzwungen |
-| 1618 | Retry | Parallele MSI laeuft |
-| 60001 | **Failed** | PSADT Unhandled Script Error |
-| 60008 | **Failed** | PSADT Init fehlgeschlagen (Module Import / Open-ADTSession) |
+| 1707 | Success | MSI success alternative |
+| 3010 | Soft reboot | Reboot recommended |
+| 1641 | Hard reboot | Reboot enforced |
+| 1618 | Retry | A parallel MSI is running |
+| 60001 | **Failed** | PSADT unhandled script error |
+| 60008 | **Failed** | PSADT init failed (module import / Open-ADTSession) |
 
-Zusaetzlich die installer-spezifischen Codes aus 0.3 eintragen.
+Additionally enter the installer-specific codes from 0.3.
 
 ### 5.4 Requirements
-- **OS architecture**: `x64` wenn Script `AppArch='x64'`, sonst entsprechend
-- **Minimum OS**: realistisch (Win11 22H2, Win10 22H2) - nicht `1607`, das ist Legacy-Offenlassen
-- **Disk space**: wenn Installer viel braucht - spart Zeit bei kleinen Platten
-- **Physical memory**: nur bei echt speicherhungrigen Installern
-- **Additional requirement rules**: Registry / File / Script - fuer alles was ueber Standardrequirements hinausgeht (z.B. Domain-Join-Pruefung, spezifische Build-Nummer)
+- **OS architecture**: `x64` when the script has `AppArch='x64'`, otherwise accordingly
+- **Minimum OS**: realistic (Win11 22H2, Win10 22H2) - not `1607`, that is leaving it open to legacy
+- **Disk space**: when the installer needs a lot - saves time on small disks
+- **Physical memory**: only for genuinely memory-hungry installers
+- **Additional requirement rules**: Registry / File / Script - for everything that goes beyond the standard requirements (e.g. domain-join check, specific build number)
 
 ### 5.5 Detection rules
 
-Drei Optionen, Reihenfolge der Robustheit:
+Three options, ordered by robustness:
 
-1. **Custom Detection Script** (bevorzugt fuer komplexe Installs):
-   - Contract: `exit 0 + stdout non-empty` = installed; `exit 0 + stdout empty` = not installed; `exit != 0` = Detection-Error, Retry
-   - Meist: `Enforce script signature check = No` (ausser in streng signierter Umgebung)
-   - Meist: `Run as 32-bit on 64-bit = No` (sonst falscher Registry-View)
+1. **Custom detection script** (preferred for complex installs):
+   - Contract: `exit 0 + stdout non-empty` = installed; `exit 0 + stdout empty` = not installed; `exit != 0` = detection error, retry
+   - Usually: `Enforce script signature check = No` (except in a strictly signed environment)
+   - Usually: `Run as 32-bit on 64-bit = No` (otherwise the wrong registry view)
 
-2. **MSI Product Code**: fuer reine MSI-Installer die ihren ProductCode stabil halten
+2. **MSI Product Code**: for pure MSI installers that keep their product code stable
 
-3. **File / Registry / Version**: fuer einfache Faelle - EIN Kriterium, nicht mehrere gemischt
+3. **File / Registry / Version**: for simple cases - ONE criterion, not several mixed
 
-**Pflicht**: Detection-Methode ist **eindeutig** - nicht Custom-Script PLUS File-Rule; das gibt widerspruechliche Antworten.
+**Mandatory**: the detection method is **unambiguous** - not a custom script PLUS a file rule; that gives contradictory answers.
 
 ### 5.6 Install time required
-- Default 60 min reicht fuer die meisten Installer
-- Nur wenn dokumentiert >45 min, hochziehen
-- Nicht reflexartig 120 min ("mehr ist besser" stimmt hier nicht - Intune behaelt den Prozess dann extrem lang am Leben)
+- The default of 60 min is enough for most installers
+- Only when documented >45 min, raise it
+- Don't reflexively set 120 min ("more is better" is not true here - Intune then keeps the process alive extremely long)
 
 ### 5.7 Assignments
-- `Required` fuer Pflicht-Rollout auf Device- oder User-Gruppe
-- `Available for enrolled devices` fuer Self-Service via Company Portal
-- `Uninstall` als Pseudo-Assignment um Apps gezielt wieder zu entfernen
-- **Filter** verwenden fuer dynamische Einschraenkungen (OS-Version, Device-Name-Regex, AzureAD-Join-Type)
-- **Delivery Optimization**: fuer grosse Pakete Peer-to-Peer aktivieren
-- **Dependencies / Supersedence**: wenn die App andere PSADT-Pakete voraussetzt oder Vorversionen ersetzt
-- **App availability / Deadline / Grace period**: fuer Required-Apps mit Reboot-Auswirkung
+- `Required` for a mandatory rollout to a device or user group
+- `Available for enrolled devices` for self-service via the Company Portal
+- `Uninstall` as a pseudo-assignment to deliberately remove apps again
+- **Filter** to use for dynamic constraints (OS version, device-name regex, AzureAD join type)
+- **Delivery Optimization**: enable peer-to-peer for large packages
+- **Dependencies / Supersedence**: when the app requires other PSADT packages or replaces previous versions
+- **App availability / Deadline / Grace period**: for required apps with a reboot impact
 
 ---
 
-## Phase 6: Test-Sequenz
+## Phase 6: Test sequence
 
-In dieser Reihenfolge auf DEV-VM (nicht Prod).
+In this order on a DEV VM (not prod).
 
-### 6.1 Direct-Invoke (Smoke-Test)
+### 6.1 Direct invoke (smoke test)
 ```powershell
 .\Invoke-AppDeployToolkit.ps1 -DeploymentType Install -DeployMode Silent
 ```
-Laeuft durch = Script-Logik OK.
-Laeuft nicht durch = dein Code-Bug, nicht Intune-Problem.
+Runs through = script logic OK.
+Does not run through = your code bug, not an Intune problem.
 
-### 6.2 Launcher-Invoke (Acid-Test)
+### 6.2 Launcher invoke (acid test)
 ```powershell
 .\Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent
 ```
-Laeuft durch = Encoding / Param-Block-Sync OK.
-Laeuft nicht durch aber 6.1 ja = siehe 3.1 (Encoding), 3.4 (Params), 3.6 (Top-Level-Throws).
+Runs through = encoding / param-block sync OK.
+Does not run through but 6.1 does = see 3.1 (encoding), 3.4 (params), 3.6 (top-level throws).
 
-### 6.3 SYSTEM-Context (IME-Realitaet)
+### 6.3 SYSTEM context (IME reality)
 ```cmd
 psexec -s -accepteula cmd /c "cd /d <pkg> && Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent"
 ```
 PsExec: https://learn.microsoft.com/en-us/sysinternals/downloads/psexec
-Laeuft durch = keine User-Session-Abhaengigkeit. Dieser Test muss gruen sein BEVOR Upload.
+Runs through = no dependency on a user session. This test must be green BEFORE upload.
 
-### 6.4 Testgruppen-Deploy
-Dedizierte Intune-Testgruppe mit 1 VM. Deployment beobachten:
-- `C:\Windows\Logs\Software\*PSAppDeployToolkit_Install.log` muss existieren + `Close-ADTSession` mit Exit 0 drin
-- `AppWorkload.log` zeigt `Status: Installed`
-- Detection-Script liefert `exit 0 + stdout non-empty`
+### 6.4 Test-group deploy
+A dedicated Intune test group with 1 VM. Observe the deployment:
+- `C:\Windows\Logs\Software\*PSAppDeployToolkit_Install.log` must exist + contain `Close-ADTSession` with Exit 0
+- `AppWorkload.log` shows `Status: Installed`
+- the detection script returns `exit 0 + stdout non-empty`
 
-Erst nach Erfolg: Production-Rollout.
+Only after success: production rollout.
 
 ---
 
 ## Phase 7: Rollout
 
-### 7.1 Staged Rollout
-- Pilot-Gruppe (10-50 Geraete) fuer 24-48h laufen lassen
-- Monitoring: Intune Admin Center -> Apps -> Oracle (Bsp.) -> Device install status
-- Bei >5% Fehlerrate: Rollout pausieren, Ursache klaeren
+### 7.1 Staged rollout
+- Run a pilot group (10-50 devices) for 24-48h
+- Monitoring: Intune Admin Center -> Apps -> Oracle (example) -> Device install status
+- At >5% failure rate: pause the rollout, find the cause
 
 ### 7.2 Production
-- Erweitern der Zielgruppen nach Pilot-Success
-- Company-Portal-Beschreibung + Support-Hinweise pruefen
-- Known-Issues in interne Wissensbasis
+- Expand the target audiences after pilot success
+- Review the Company Portal description + support notes
+- Known issues into the internal knowledge base
 
 ### 7.3 Ongoing
-- GitHub-Release-Feed abonnieren (Releases -> Watch -> Releases only) um PSADT-Updates nicht zu verschlafen
-- Pruefen bei jedem neuen Paket: ist das Modul im Scaffold noch aktuell (Phase 0.1)
+- Subscribe to the GitHub release feed (Releases -> Watch -> Releases only) so you don't miss PSADT updates
+- Check with every new package: is the module in the scaffold still up to date (Phase 0.1)
 
 ---
 
-## Anhang A: Error-Referenz
+## Appendix A: Error reference
 
-### A.1 Intune-HRESULT-Mapping
+### A.1 Intune HRESULT mapping
 
-Intune rechnet unbekannte positive Exit-Codes in HRESULT um: `0x80070000 + exitcode`.
+Intune converts unknown positive exit codes into an HRESULT: `0x80070000 + exitcode`.
 
-| Intune zeigt | Tatsaechlicher Exit | Bedeutung |
+| Intune shows | Actual exit | Meaning |
 |---|---:|---|
-| `0x80070001` | 1 | **Script ist gar nicht gelaufen** (Parse-Error, Param-Binding, Top-Level-Throw) |
-| `0x80070002` | 2 | FILE_NOT_FOUND, oft: Launcher findet .ps1 nicht |
-| `0x8000EA61` | 60001 | PSADT Unhandled Script Error |
-| `0x8000EA68` | 60008 | PSADT Init / Module-Load fehlgeschlagen |
-| `0x8007064B` | 1611 | MSI Component qualifier not present |
+| `0x80070001` | 1 | **The script did not run at all** (parse error, param binding, top-level throw) |
+| `0x80070002` | 2 | FILE_NOT_FOUND, often: the launcher cannot find the .ps1 |
+| `0x8000EA61` | 60001 | PSADT unhandled script error |
+| `0x8000EA68` | 60008 | PSADT init / module load failed |
+| `0x8007064B` | 1611 | MSI component qualifier not present |
 | `0x80070642` | 1602 | User cancelled |
 | `0x80070652` | 1618 | Another install in progress |
 | `0x0` | 0 | Success |
 
-### A.2 Typische Root-Causes nach Symptom
+### A.2 Typical root causes by symptom
 
-**0x80070001 + keine lokalen PSADT-Logs:**
-1. Script-Encoding (Em-Dash in Double-Quote-String, UTF-8 ohne BOM) -> Parse-Error
-2. Top-Level-Code ausserhalb try/catch throwt
-3. Param-Block akzeptiert nicht was Launcher uebergibt
+**0x80070001 + no local PSADT logs:**
+1. Script encoding (em-dash in a double-quoted string, UTF-8 without BOM) -> parse error
+2. Top-level code outside try/catch throws
+3. The param block does not accept what the launcher passes
 -> 3.1, 3.4, 3.6
 
-**0x8000EA68 (60008) + PSADT-Log vorhanden, aber leer nach Init:**
-1. Import-Module-Fehler (Version-Mismatch, Path kaputt)
-2. Open-ADTSession wirft (Config ungueltig, Admin-Check failed)
-3. Typdaten-Kollision (`System.Security.AccessControl`) - Symptom `"AuditToString" ist bereits vorhanden`. IME laeuft als SYSTEM mit Machine-Scope PSModulePath (sauber), daher selten in Intune-Deploy - eher in Interactive-Tests. Workaround: `$env:PSModulePath` um PS7-Pfade bereinigen.
+**0x8000EA68 (60008) + PSADT log present, but empty after init:**
+1. Import-Module error (version mismatch, broken path)
+2. Open-ADTSession throws (invalid config, admin check failed)
+3. Type-data collision (`System.Security.AccessControl`) - symptom `"AuditToString" ist bereits vorhanden`. The IME runs as SYSTEM with a machine-scope PSModulePath (clean), so it's rare in an Intune deploy - more likely in interactive tests. Workaround: clean PS7 paths out of `$env:PSModulePath`.
 
-**0x8000EA61 (60001) + PSADT-Log mit Stacktrace:**
-1. Runtime-Fehler in Install-ADTDeployment
-2. External-Command scheitert
--> Log selbst hat den Stack, direkt lesbar
+**0x8000EA61 (60001) + PSADT log with a stack trace:**
+1. Runtime error in Install-ADTDeployment
+2. An external command fails
+-> the log itself has the stack, directly readable
 
-**App haengt auf "Installing" in Company Portal:**
-1. Script laeuft noch (Prozess-ID, Scheduled-Task-State checken)
-2. Script abgestuerzt, IME-Callback nicht geschrieben
-3. GRS-Cache im Weg
+**App stuck on "Installing" in the Company Portal:**
+1. The script is still running (check the process ID, scheduled-task state)
+2. The script crashed, the IME callback was not written
+3. The GRS cache is in the way
 
-Aufraeum-Sequenz (Vorsicht, erst pruefen):
+Cleanup sequence (caution, check first):
 ```powershell
 Get-Process | Where-Object { $_.ProcessName -match 'Invoke-AppDeployToolkit|setup|msiexec|dbca|sqlplus' } | Select Id,ProcessName,StartTime
 Get-ScheduledTask -TaskName 'PSADT_*' -ErrorAction SilentlyContinue | Select TaskName,State
@@ -654,48 +654,48 @@ Remove-Item 'HKLM:\SOFTWARE\Microsoft\IntuneManagementExtension\Win32Apps\<UserS
 Start-Service IntuneManagementExtension
 ```
 
-### A.3 Log-Fundorte
+### A.3 Log locations
 
-| Log | Zweck |
+| Log | Purpose |
 |---|---|
-| `C:\Windows\Logs\Software\<AppName>*PSAppDeployToolkit_Install.log` | PSADT-Session (nach erfolgreichem Init) |
-| `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\AppWorkload.log` | **Wahrheit** zu Exit-Codes + Install-Commands |
-| `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\IntuneManagementExtension.log` | IME-Service-State |
-| `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\AgentExecutor.log` | Detection-Script-Runs |
-| `C:\Windows\IMECache\<AppId>_<Version>\` | Entpacktes Paket (nur waehrend Install) |
-| `C:\Program Files (x86)\Microsoft Intune Management Extension\Content\Incoming\` | .intunewin-Download (vor Extract) |
+| `C:\Windows\Logs\Software\<AppName>*PSAppDeployToolkit_Install.log` | PSADT session (after a successful init) |
+| `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\AppWorkload.log` | **The truth** about exit codes + install commands |
+| `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\IntuneManagementExtension.log` | IME service state |
+| `C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\AgentExecutor.log` | Detection-script runs |
+| `C:\Windows\IMECache\<AppId>_<Version>\` | Extracted package (only during install) |
+| `C:\Program Files (x86)\Microsoft Intune Management Extension\Content\Incoming\` | .intunewin download (before extract) |
 
-AppWorkload.log-Sequenz:
-- `Content cache miss for app (id = ..., name = ...)` - Download startet
-- `Downloading app ... via DO, bytes N/M` - Progress
-- `SetCurrentDirectory: C:\WINDOWS\IMECache\...` - Extract done
-- `Calling CreateProcessAsUser: '...Invoke-AppDeployToolkit.exe...'` - Echter Start
-- `lpExitCode N` - Exit-Code
-- `Admin did NOT set mapping for lpExitCode: N` - Code war nicht in Return-Codes
-- `EnforcementErrorCode: -<huge>` - HRESULT als signed int
-
----
-
-## Anhang B: Anti-Pattern-Liste
-
-1. **Em-Dash/Smart-Quote in Double-Quoted Strings**. `"Repair failed — DB status [$status]."` killt das ganze Script.
-2. **UTF-8 ohne BOM + Sonderzeichen**. BOM schreiben oder reines ASCII.
-3. **v3-Cmdlet-Namen** (siehe 3.5).
-4. **Top-Level-Code ausserhalb try/catch**.
-5. **Single-Check ohne Retry fuer async State** (Services nach msiexec brauchen 30-60s; Fallback-Loesch-Aktionen nicht bei erster negativer Antwort triggern).
-6. **Intune Return Codes nur Default**. 60001 + 60008 als Failed eintragen.
-7. **Install time reflexartig hochsetzen**. 60 min ist fast immer richtig.
-8. **Denken "Laeuft lokal = laeuft in Intune"**. Acid-Test ist 6.2 + 6.3.
-9. **Detection gemischt** (Custom-Script + File-Rule parallel).
-10. **Extensions im Main-Script statt in `PSAppDeployToolkit.Extensions`**.
-11. **-o ins -c beim IntuneWinAppUtil** - nested .intunewin.
-12. **Kein Stakeholder-Intake (Phase 0.2)** - haeufigster Grund fuer "Installer macht nicht was ich will" nach 2 Wochen.
+AppWorkload.log sequence:
+- `Content cache miss for app (id = ..., name = ...)` - download starts
+- `Downloading app ... via DO, bytes N/M` - progress
+- `SetCurrentDirectory: C:\WINDOWS\IMECache\...` - extract done
+- `Calling CreateProcessAsUser: '...Invoke-AppDeployToolkit.exe...'` - the real start
+- `lpExitCode N` - exit code
+- `Admin did NOT set mapping for lpExitCode: N` - the code was not in the return codes
+- `EnforcementErrorCode: -<huge>` - HRESULT as a signed int
 
 ---
 
-## Anhang C: Test-Stub-Muster
+## Appendix B: Anti-pattern list
 
-Vor Launcher-Test auf DEV-Box, wenn Install-Aktion zu gross/teuer:
+1. **Em-dash/smart quote in double-quoted strings**. `"Repair failed — DB status [$status]."` kills the entire script.
+2. **UTF-8 without BOM + special characters**. Write a BOM or stick to pure ASCII.
+3. **v3 cmdlet names** (see 3.5).
+4. **Top-level code outside try/catch**.
+5. **Single check without retry for async state** (services after msiexec need 30-60s; do not trigger fallback delete actions on the first negative answer).
+6. **Intune return codes left at default only**. Enter 60001 + 60008 as Failed.
+7. **Reflexively bumping the install time**. 60 min is almost always right.
+8. **Thinking "runs locally = runs in Intune"**. The acid test is 6.2 + 6.3.
+9. **Mixed detection** (custom script + file rule in parallel).
+10. **Extensions in the main script instead of in `PSAppDeployToolkit.Extensions`**.
+11. **-o inside -c with IntuneWinAppUtil** - nested .intunewin.
+12. **No stakeholder intake (Phase 0.2)** - the most common reason for "the installer doesn't do what I want" after 2 weeks.
+
+---
+
+## Appendix C: Test stub pattern
+
+Before the launcher test on a DEV box, when the install action is too big/expensive:
 
 ```powershell
 $orig = '<pfad-zur-ps1>'
@@ -712,28 +712,28 @@ Start-Process powershell.exe -ArgumentList `
 Get-Content "$env:TEMP\stub-reached.log" -ErrorAction SilentlyContinue
 ```
 
-- Exit 77 + Stub-Log = Init + Session-Open OK, Bug sitzt in Install-ADTDeployment
-- Exit 1 = Parse/Encoding-Bug, siehe 3.1
-- Exit 60008 = Import-Module / Open-ADTSession Bug, siehe A.2
+- Exit 77 + stub log = init + session open OK, the bug sits in Install-ADTDeployment
+- Exit 1 = parse/encoding bug, see 3.1
+- Exit 60008 = Import-Module / Open-ADTSession bug, see A.2
 
 ---
 
-## Anhang D: Ressourcen
+## Appendix D: Resources
 
-### Offizielles PSADT
-- Hauptseite + Docs: https://psappdeploytoolkit.com/docs
-- Latest Release: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/releases/latest
-- Release Notes: https://psappdeploytoolkit.com/docs/getting-started/release-notes
+### Official PSADT
+- Main site + docs: https://psappdeploytoolkit.com/docs
+- Latest release: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/releases/latest
+- Release notes: https://psappdeploytoolkit.com/docs/getting-started/release-notes
 - Download: https://psappdeploytoolkit.com/docs/getting-started/download
 - Creating a New Deployment: https://psappdeploytoolkit.com/docs/getting-started/creating-a-new-deployment
-- Reference (alle Cmdlets): https://psappdeploytoolkit.com/docs/reference
+- Reference (all cmdlets): https://psappdeploytoolkit.com/docs/reference
 - New-ADTTemplate: https://psappdeploytoolkit.com/docs/reference/functions/New-ADTTemplate
 - Exit Codes: https://psappdeploytoolkit.com/docs/reference/exit-codes
 - Migration v3 -> v4: https://psappdeploytoolkit.com/docs/migration/migrate-from-v3
 - Blog: https://psappdeploytoolkit.com/blog
 - Community Forum: https://discourse.psappdeploytoolkit.com
 - GitHub: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit
-- Launcher-Source: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/tree/main/src/PSADT.Invoke
+- Launcher source: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/tree/main/src/PSADT.Invoke
 
 ### Microsoft
 - Intune Win32 App Docs: https://learn.microsoft.com/en-us/mem/intune/apps/apps-win32-app-management
@@ -741,19 +741,19 @@ Get-Content "$env:TEMP\stub-reached.log" -ErrorAction SilentlyContinue
 - IntuneWinAppUtil Releases: https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/releases/latest
 - Intune Troubleshooting: https://learn.microsoft.com/en-us/mem/intune/apps/troubleshoot-app-install
 - Company Portal Docs: https://learn.microsoft.com/en-us/mem/intune/apps/company-portal-app
-- PowerShell 5.1 UTF-8-No-BOM-Bug: https://learn.microsoft.com/en-us/answers/questions/3850223/powershell-5-1-parser-bug-failure-to-parse-utf-8
+- PowerShell 5.1 UTF-8-No-BOM bug: https://learn.microsoft.com/en-us/answers/questions/3850223/powershell-5-1-parser-bug-failure-to-parse-utf-8
 - PowerShell File Encoding: https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/understanding-file-encoding
 - about_Character_Encoding: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding
 - PsExec (SysInternals): https://learn.microsoft.com/en-us/sysinternals/downloads/psexec
 
-### Silent-Install-Recherche
-- silentinstallhq.com - Switch-Sammlung
-- deploymentresearch.com - Tim Mangan Archiv
+### Silent-install research
+- silentinstallhq.com - switch collection
+- deploymentresearch.com - Tim Mangan archive
 - PSADT Discourse Search: https://discourse.psappdeploytoolkit.com/search
 - Reddit r/Intune: https://www.reddit.com/r/Intune/
 - Reddit r/SCCM: https://www.reddit.com/r/SCCM/
 
-### Drittdocs Error-Codes
+### Third-party error-code docs
 - Scappman Error Reference: https://support.scappman.com/support/error-code-reference
 - xoap PSADT Exit Codes: https://docs.xoap.io/application-management/psadt/exit-codes
 - netECM PSADT Exit Codes: https://docs.netecm.ch/launcher/troubleshooting/ps-app-deploy-toolkit-setup-exit-codes.html
@@ -762,7 +762,7 @@ Get-Content "$env:TEMP\stub-reached.log" -ErrorAction SilentlyContinue
 
 ---
 
-## Anhang E: Finale Deploy-Checkliste
+## Appendix E: Final deploy checklist
 
 ```
 Phase 0 - Recherche + Intake
@@ -815,35 +815,37 @@ Phase 7 - Rollout
 [ ] 7.3  GitHub-Release-Watch abonniert
 ```
 
-Erst wenn ALLE Zeilen gruen: Production-Rollout.
+Only when ALL lines are green: production rollout.
 
 ---
 
-## Anhang F: Intune-Deployment-Dossier (Upload-Template, pro App auszufuellen)
+## Appendix F: Intune deployment dossier (upload template, to be filled in per app)
 
-Dieses Template als Markdown-Datei pro App neben das `.intunewin` legen (z.B. `<AppName>-IntuneDossier.md`). Ohne ausgefuelltes Dossier: **kein Upload**. Werte kommen aus Phase 0.2/0.3.
+Place this template as a Markdown file per app next to the `.intunewin` (e.g. `<AppName>-IntuneDossier.md`). Without a filled-in dossier: **no upload**. The values come from Phase 0.2/0.3.
 
 ### F.1 App information
 
-| Intune-Feld | Wert | Hinweise |
+| Intune field | Value | Notes |
 |---|---|---|
-| **Name** | `<AppName> <Version>` | exakt wie im Company Portal sichtbar; Version inkl. Build falls Updates |
-| **Description** | siehe F.2 (Markdown-Block) | erste ~200 Zeichen sind Kurzvorschau im CP |
-| **Publisher** | `<Hersteller>` | aus Phase 0.2 (Adobe Inc., Oracle Corporation, ...) |
-| **App version** | `<Major.Minor.Build.Rev>` | exakt Dateiversion |
-| **Category** | z.B. Business, Development, Productivity, Communication | fuer CP-Navigation |
-| **Show this as a featured app in the Company Portal** | Yes/No | Yes nur fuer empfohlene Self-Service-Apps |
-| **Information URL** | `<hersteller-produktseite>` | offizielle Produkt-Homepage |
-| **Privacy URL** | `<hersteller-privacy-url>` | oft `/legal/privacy/` des Herstellers |
-| **Developer** | `<Hersteller-Kurzname>` | meist == Publisher |
-| **Owner** | `<internes-Team>` | interner Service-Owner (z.B. "Workplace-Services") |
-| **Notes** | `PSADT 4.1.8 v<N> - pkg rev <NN> - YYYY-MM-DD` | Paket-Metadaten fuer spaetere Troubleshootings |
+| **Name** | `<AppName> <Version>` | exactly as visible in the Company Portal; version incl. build if there are updates |
+| **Description** | see F.2 (Markdown block) | the first ~200 characters are the short preview in the CP |
+| **Publisher** | `<Hersteller>` | from Phase 0.2 (Adobe Inc., Oracle Corporation, ...) |
+| **App version** | `<Major.Minor.Build.Rev>` | exact file version |
+| **Category** | e.g. Business, Development, Productivity, Communication | for CP navigation |
+| **Show this as a featured app in the Company Portal** | Yes/No | Yes only for recommended self-service apps |
+| **Information URL** | `<hersteller-produktseite>` | official product homepage |
+| **Privacy URL** | `<hersteller-privacy-url>` | often the vendor's `/legal/privacy/` |
+| **Developer** | `<Hersteller-Kurzname>` | usually == Publisher |
+| **Owner** | `<internes-Team>` | internal service owner (e.g. "Workplace-Services") |
+| **Notes** | `PSADT 4.1.8 v<N> - pkg rev <NN> - YYYY-MM-DD` | package metadata for later troubleshooting |
 | **Logo** | `<pkg>\Assets\AppIcon.png` | 256x256 PNG transparent |
-| **Role scope tags** | `<Default>` oder custom | nur bei delegierter Admin-Rollenstruktur |
+| **Role scope tags** | `<Default>` or custom | only with a delegated admin role structure |
 
-### F.2 Description-Markdown-Template (Company Portal)
+### F.2 Description Markdown template (Company Portal)
 
-Intune rendert Markdown im Company Portal. Block 1:1 kopieren, `<...>` ersetzen.
+Intune renders Markdown in the Company Portal. Copy the block 1:1, replace `<...>`.
+
+(end-user output — language.dossier, default German)
 
 ```markdown
 **<AppName>** ist <Ein-Satz-Zweck>.
@@ -877,22 +879,22 @@ Intune rendert Markdown im Company Portal. Block 1:1 kopieren, `<...>` ersetzen.
 Bei Problemen bitte ein Ticket beim **IT-Service-Desk** eroeffnen und - wenn moeglich - die Logdateien unter `C:\Windows\Logs\Software\` anhaengen.
 ```
 
-Pruefen: erster Absatz muss auch allein lesbar sein (200-Zeichen-Kurzvorschau).
+Check: the first paragraph must also be readable on its own (200-character short preview).
 
 ### F.3 Program
 
-| Intune-Feld | Wert |
+| Intune field | Value |
 |---|---|
 | **Install command** | `Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent` |
-| **Install script** | - (nicht verwenden, Command reicht) |
+| **Install script** | - (do not use, the command is enough) |
 | **Uninstall command** | `Invoke-AppDeployToolkit.exe -DeploymentType Uninstall -DeployMode Silent` |
 | **Uninstall script** | - |
-| **Installation time required (mins)** | Default 60; nur wenn >45 min dokumentiert hochziehen |
-| **Allow available uninstall** | Yes (User darf via CP deinstallieren) |
+| **Installation time required (mins)** | Default 60; only raise if >45 min documented |
+| **Allow available uninstall** | Yes (the user may uninstall via the CP) |
 | **Install behavior** | **System** |
-| **Device restart behavior** | `Determine behavior based on return codes` (Default) ODER `App install may force a device restart` wenn Installer 1641 liefern kann |
+| **Device restart behavior** | `Determine behavior based on return codes` (default) OR `App install may force a device restart` when the installer can return 1641 |
 
-### F.4 Return codes (Pflicht-Tabelle, exakt uebernehmen)
+### F.4 Return codes (mandatory table, copy exactly)
 
 | Code | Type |
 |---:|---|
@@ -906,112 +908,112 @@ Pruefen: erster Absatz muss auch allein lesbar sein (200-Zeichen-Kurzvorschau).
 | `<installer-success-nicht-0>` | Success |
 | `<installer-known-error>` | Failed |
 
-Installer-spezifische Codes aus Phase 0.3 ergaenzen. Jeder unbekannte Exit-Code erzeugt `0x80070000+code` in der Fehleranzeige.
+Add the installer-specific codes from Phase 0.3. Every unknown exit code produces `0x80070000+code` in the error display.
 
 ### F.5 Requirements
 
-| Intune-Feld | Wert | Hinweise |
+| Intune field | Value | Notes |
 |---|---|---|
-| **Operating system architecture** | x64 / x86 / Both | matched zu `$adtSession.AppArch` |
-| **Minimum operating system** | Win11 22H2 / Win10 22H2 | realitaetsnah, nicht "Win10 1607" |
-| **Disk space required (MB)** | `<MB>` | aus Installer-Anforderung, Netto + 20% Reserve |
-| **Physical memory required (MB)** | `<MB>` oder leer | nur bei RAM-hungrigen Installern |
-| **Minimum number of logical processors required** | 1 / 2 / 4 | selten relevant |
-| **Minimum CPU speed required (MHz)** | leer | selten relevant |
-| **Additional requirement rules** | optional | Registry/File/Script - z.B. "Domain-Joined", "hat Edge-WebView2 installiert" |
+| **Operating system architecture** | x64 / x86 / Both | matches `$adtSession.AppArch` |
+| **Minimum operating system** | Win11 22H2 / Win10 22H2 | realistic, not "Win10 1607" |
+| **Disk space required (MB)** | `<MB>` | from the installer requirement, net + 20% reserve |
+| **Physical memory required (MB)** | `<MB>` or empty | only for RAM-hungry installers |
+| **Minimum number of logical processors required** | 1 / 2 / 4 | rarely relevant |
+| **Minimum CPU speed required (MHz)** | empty | rarely relevant |
+| **Additional requirement rules** | optional | Registry/File/Script - e.g. "Domain-Joined", "has Edge WebView2 installed" |
 
 ### F.6 Detection rules
 
-**Rules format:** einen Weg waehlen, NICHT mischen:
+**Rules format:** choose one way, do NOT mix:
 
-**Option A - Custom script (bevorzugt fuer komplexe Installs):**
-| Feld | Wert |
+**Option A - Custom script (preferred for complex installs):**
+| Field | Value |
 |---|---|
 | **Rules format** | Use a custom detection script |
-| **Script file** | `Detect-<AppName>.ps1` (mit Paket ausgeliefert) |
-| **Run script as 32-bit process on 64-bit clients** | No (ausser das Script liest bewusst Wow6432Node) |
-| **Enforce script signature check** | No (es sei denn in streng signierter Umgebung) |
+| **Script file** | `Detect-<AppName>.ps1` (shipped with the package) |
+| **Run script as 32-bit process on 64-bit clients** | No (unless the script deliberately reads Wow6432Node) |
+| **Enforce script signature check** | No (unless in a strictly signed environment) |
 
-Detection-Script-Contract:
+Detection-script contract:
 - `exit 0 + stdout non-empty` -> INSTALLED
 - `exit 0 + stdout empty` -> NOT INSTALLED
-- `exit != 0` -> Detection-Error (Intune retriet)
+- `exit != 0` -> detection error (Intune retries)
 
-**Option B - Manuell, MSI Product Code:**
-| Feld | Wert |
+**Option B - Manual, MSI Product Code:**
+| Field | Value |
 |---|---|
 | **Rule type** | MSI |
 | **MSI product code** | `{GUID}` |
-| **MSI product version check** | No ODER operator + version |
+| **MSI product version check** | No OR operator + version |
 
-**Option C - Manuell, File/Registry:**
-EINE Regel reicht wenn eindeutig. Mehrere Regeln mischen: mit Bedacht, alle muessen matchen.
+**Option C - Manual, File/Registry:**
+ONE rule is enough if unambiguous. Mixing several rules: with care, all must match.
 
-| Feld | Wert |
+| Field | Value |
 |---|---|
 | **Rule type** | File / Registry / App version |
 | **Path / Key** | `<konkret>` |
 | **File/value** | `<konkret>` |
 | **Detection method** | exists / string / version / size / date modified |
-| **Associated with a 32-bit app on 64-bit clients** | No (fast immer) |
+| **Associated with a 32-bit app on 64-bit clients** | No (almost always) |
 
 ### F.7 Dependencies
 
-Andere Win32-Apps die ZUERST installiert sein muessen.
+Other Win32 apps that must be installed FIRST.
 
-| Feld | Wert |
+| Field | Value |
 |---|---|
-| **Dependency app** | z.B. "VC++ 2015-2022 x64" |
-| **Automatically install** | Yes (Intune installiert automatisch nach) |
+| **Dependency app** | e.g. "VC++ 2015-2022 x64" |
+| **Automatically install** | Yes (Intune installs it automatically afterwards) |
 
-Zirkulaere Abhaengigkeiten und >3 Ebenen vermeiden.
+Avoid circular dependencies and >3 levels.
 
 ### F.8 Supersedence
 
-Ersetzt diese App eine Vorversion oder ein anderes Produkt?
+Does this app replace a previous version or another product?
 
-| Feld | Wert |
+| Field | Value |
 |---|---|
-| **Superseded app** | vorherige Version (separater Intune-Eintrag) |
-| **Uninstall previous version** | Yes/No (Yes wenn echter Replace, No wenn parallel moeglich) |
+| **Superseded app** | the previous version (separate Intune entry) |
+| **Uninstall previous version** | Yes/No (Yes for a true replace, No when parallel is possible) |
 
-Maximal **10 Apps** als superseded; **maximal 2 Ebenen** tief (Intune-Limit).
+A maximum of **10 apps** as superseded; **at most 2 levels** deep (Intune limit).
 
 ### F.9 Assignments
 
-Pro Zielgruppe eine Zeile. Mindestens eine Required- ODER Available-Assignment, sonst nie installiert.
+One row per target group. At least one Required OR Available assignment, otherwise it never installs.
 
-| Group (AzureAD / Entra) | Assignment type | Filter (include/exclude) | Install-Availability | Deadline | Restart grace period | Delivery Optimization |
+| Group (AzureAD / Entra) | Assignment type | Filter (include/exclude) | Install availability | Deadline | Restart grace period | Delivery Optimization |
 |---|---|---|---|---|---|---|
-| `<Grp-Devices-Required>` | Required | optional Filter | As soon as possible / Datum | optional Datum | 1440 min + 15 min vor Reboot | Foreground / Background |
-| `<Grp-Users-OptIn>` | Available | optional Filter | - | - | - | Background |
+| `<Grp-Devices-Required>` | Required | optional filter | As soon as possible / date | optional date | 1440 min + 15 min before reboot | Foreground / Background |
+| `<Grp-Users-OptIn>` | Available | optional filter | - | - | - | Background |
 | `<Grp-Cleanup>` | Uninstall | - | - | - | - | - |
 
 **Hints:**
-- Required fuer Pflicht-Rollouts (Security, Compliance, Standard-Tools)
-- Available fuer Self-Service
-- Uninstall fuer gezieltes Entfernen aus Gruppe
-- Filter: Plattform/Version/DeviceName-Regex; bei Edge-Cases prueft IME sauber ob Filter-Property existiert
-- Delivery Optimization Foreground bei Pakete die sofort kommen muessen; Background schont Netz bei grossen Paketen
+- Required for mandatory rollouts (security, compliance, standard tools)
+- Available for self-service
+- Uninstall for targeted removal from a group
+- Filter: platform/version/device-name regex; for edge cases the IME checks cleanly whether the filter property exists
+- Delivery Optimization Foreground for packages that have to arrive immediately; Background spares the network for large packages
 
-**End user notifications** (pro Assignment):
-- `Show all toast notifications` - Default, User sieht Download/Install/Reboot
-- `Show toast notifications for computer restarts` - nur Reboot-Prompt
-- `Hide all toast notifications` - nur fuer silent-only-Apps
+**End user notifications** (per assignment):
+- `Show all toast notifications` - default, the user sees download/install/reboot
+- `Show toast notifications for computer restarts` - only the reboot prompt
+- `Hide all toast notifications` - only for silent-only apps
 
 ### F.10 Review + Create
 
-Vor dem `Create` alle Tabs durchgehen. Nach `Create`: Intune synct nicht sofort — 30-60 min Wartezeit bis Client das Paket sieht. Manuell triggern via Company Portal -> Einstellungen -> Sync.
+Before the `Create`, go through all tabs. After `Create`: Intune does not sync immediately — there is a 30-60 min wait until the client sees the package. Trigger it manually via Company Portal -> Settings -> Sync.
 
-### F.11 Beispielhafte Ausfuellung (Oracle Database 21c XE aus diesem Projekt)
+### F.11 Example filled-in (Oracle Database 21c XE from this project)
 
-| Feld | Wert |
+| Field | Value |
 |---|---|
 | Name | Oracle Database 21c Express Edition |
 | Publisher | Oracle Corporation |
 | App version | 21.0.0.0 |
 | Category | Development, Database |
-| Featured | Yes (fuer Developer-Zielgruppe) |
+| Featured | Yes (for the developer audience) |
 | Information URL | https://docs.oracle.com/en/database/oracle/oracle-database/21/xeinw/ |
 | Privacy URL | https://www.oracle.com/legal/privacy/ |
 | Developer | Oracle |
@@ -1029,31 +1031,31 @@ Vor dem `Create` alle Tabs durchgehen. Nach `Create`: Intune synct nicht sofort 
 | Disk space required | 12288 MB |
 | Physical memory | 4096 MB |
 | Detection | Custom script `Detect-OracleXE.ps1`, Run as 32-bit=No, Signature=No |
-| Dependencies | - (VCRedist ist im PSADT-Pre-Install-Hook integriert) |
-| Supersedence | - (erste Version) |
+| Dependencies | - (VCRedist is integrated in the PSADT pre-install hook) |
+| Supersedence | - (first version) |
 | Required group | Devices-OracleXE-Dev |
 | Available group | Users-OracleXE-OptIn |
 | Install availability | As soon as possible |
 | Restart grace period | 1440 min (24h), 15 min countdown, snooze 240 min |
 
-Das ist ein vollstaendiges Dossier. Jede neue App genauso durchgehen.
+That is a complete dossier. Go through every new app the same way.
 
 ---
 
-## Anhang G: Lessons Learned (aus Praxis-Vorfaellen)
+## Appendix G: Lessons Learned (from real-world incidents)
 
-Diese Lessons stammen aus konkreten Paketierungs-Projekten und gelten fuer PSADT-v4-Intune-Deployments allgemein - nicht app-spezifisch. Jeder neue Vorfall wird hier als neuer Eintrag ergaenzt (Format: Datum, Symptom, Ursache, Fix, allgemeine Lehre).
+These lessons come from concrete packaging projects and apply to PSADT v4 Intune deployments in general - not app-specific. Every new incident is added here as a new entry (format: date, symptom, cause, fix, general lesson).
 
-### 2026-04-21/22 - Datenbank-Paket (grosser Installer, ~2 GB, mit Post-Install-DB-Verify)
+### 2026-04-21/22 - Database package (large installer, ~2 GB, with post-install DB verify)
 
-1. **Em-Dash-Encoding-Bug**: Script hatte 74 Em-Dashes (`—`) als UTF-8 ohne BOM. In Double-Quoted Strings brach PowerShell 5.1 beim Parsen. Exit 1, Intune zeigte `0x80070001`, keine lokalen Logs. Fix: alle Em-Dashes zu `-`, Pfeile `→` zu `->`, UTF-8 BOM gesetzt.
+1. **Em-dash encoding bug**: the script had 74 em-dashes (`—`) as UTF-8 without a BOM. In double-quoted strings PowerShell 5.1 broke during parsing. Exit 1, Intune showed `0x80070001`, no local logs. Fix: all em-dashes to `-`, arrows `→` to `->`, set the UTF-8 BOM.
 
-2. **Transiente Post-Install-Check-False-Positive**: Funktionaler Check direkt nach `msiexec`-Ende lief ins Leere - die durch den Installer registrierten Services waren noch in `Starting`, Listener/API noch nicht erreichbar. Der Single-Check gab `NO_OUTPUT` / leeres Resultat zurueck, das als "nicht installiert" interpretierte Script triggerte eine 30-minuetige Drop+Recreate-Fallback-Aktion - obwohl die Installation eigentlich erfolgreich war. Fix: erst auf Service=Running warten (max 3 min), dann Check-Funktion mit Retry-Loop (6x, 30s Abstand), erst danach Fallback. **Generelle Lesson**: fuer jeden Post-Install-Check der auf asynchron gestarteten State angewiesen ist (Services, Listener, Registry-Keys die ein Dienst schreibt) IMMER Retry-Loop + Service-Ready-Wait, nie Single-Shot. Gilt fuer alle Installer mit Dienst-Registrierung (DBs, Message-Queues, Search-Indexer, Lizenz-Daemons, ...).
+2. **Transient post-install-check false positive**: a functional check right after `msiexec` finished came up empty - the services registered by the installer were still in `Starting`, the listener/API not yet reachable. The single check returned `NO_OUTPUT` / an empty result, which the script interpreted as "not installed" and triggered a 30-minute drop+recreate fallback action - even though the installation was actually successful. Fix: first wait for the service to be Running (max 3 min), then a check function with a retry loop (6x, 30s apart), and only after that the fallback. **General lesson**: for every post-install check that depends on asynchronously started state (services, listeners, registry keys that a service writes) ALWAYS use a retry loop + service-ready wait, never single-shot. Applies to all installers with service registration (DBs, message queues, search indexers, license daemons, ...).
 
-3. **IME-HRESULT-Mapping-Falle**: `0x80070001` sieht aus wie "ERROR_INVALID_FUNCTION" (Win32-API), ist aber `0x80070000 + 1`, also Exit 1 aus dem Script. Immer gegenrechnen.
+3. **IME HRESULT mapping trap**: `0x80070001` looks like "ERROR_INVALID_FUNCTION" (Win32 API), but it is `0x80070000 + 1`, i.e. exit 1 from the script. Always do the math.
 
-4. **IntuneManagementExtension.log vs AppWorkload.log**: IntuneManagementExtension.log zeigt Service-State und State-Machine-Definitionen ("Adding new state transition..." sind nur Tabelleneintraege, KEINE echten Transitions). Fuer Install-Diagnose ist **AppWorkload.log** der Treffer.
+4. **IntuneManagementExtension.log vs AppWorkload.log**: IntuneManagementExtension.log shows the service state and state-machine definitions ("Adding new state transition..." are just table entries, NOT real transitions). For install diagnosis **AppWorkload.log** is the hit.
 
-5. **Acid-Test ist `Invoke-AppDeployToolkit.exe`, nicht `.ps1` direkt**. Die Launcher-Exe nutzt `powershell.exe -Command "try { & 'script.ps1' ... } catch { throw }; exit $Global:LASTEXITCODE"` - ein anderer Encoding-Pfad als `.\script.ps1`. Encoding-Bugs fallen nur hier auf.
+5. **The acid test is `Invoke-AppDeployToolkit.exe`, not `.ps1` directly**. The launcher exe uses `powershell.exe -Command "try { & 'script.ps1' ... } catch { throw }; exit $Global:LASTEXITCODE"` - a different encoding path than `.\script.ps1`. Encoding bugs only show up here.
 
-6. **Falsche Param-Block-Diagnose vermeiden**: Ich habe zwischenzeitlich `$SuppressRebootPassThru` zu `$AllowRebootPassThru` geaendert - v3-Denken angewandt auf ein v4-Script. Der Launcher uebergibt NICHT automatisch Reboot-Switches; der Parametername ist in v4.x `$SuppressRebootPassThru`. Referenz ist IMMER das Template unter `<pkg>\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1`.
+6. **Avoid a wrong param-block diagnosis**: at one point I changed `$SuppressRebootPassThru` to `$AllowRebootPassThru` - v3 thinking applied to a v4 script. The launcher does NOT automatically pass reboot switches; the parameter name in v4.x is `$SuppressRebootPassThru`. The reference is ALWAYS the template under `<pkg>\PSAppDeployToolkit\Frontend\v4\Invoke-AppDeployToolkit.ps1`.

--- a/references/PSADTv4-Deployment-Guide.md
+++ b/references/PSADTv4-Deployment-Guide.md
@@ -765,54 +765,54 @@ Get-Content "$env:TEMP\stub-reached.log" -ErrorAction SilentlyContinue
 ## Appendix E: Final deploy checklist
 
 ```
-Phase 0 - Recherche + Intake
-[ ] 0.1  PSADT-Version lokal == Latest (oder Update)
-[ ] 0.2  Intake-Formular komplett (App, Installer, Environment, Sec)
-[ ] 0.3  Silent-Install-Switches + Uninstall-Switches dokumentiert
+Phase 0 - Research + Intake
+[ ] 0.1  PSADT version local == Latest (or update)
+[ ] 0.2  Intake form complete (App, Installer, Environment, Sec)
+[ ] 0.3  Silent install switches + uninstall switches documented
 
 Phase 1 - Scaffold
-[ ] 1.1  New-ADTTemplate -Destination ... -Name ... ausgefuehrt
-[ ] 1.2  Folder-Layout komplett
-[ ] 1.3  Modul-Version im Scaffold gepinnt
+[ ] 1.1  New-ADTTemplate -Destination ... -Name ... executed
+[ ] 1.2  Folder layout complete
+[ ] 1.3  Module version pinned in scaffold
 
-Phase 2 - Script-Customizing
+Phase 2 - Script customizing
 [ ] 2.1  Installer in Files\
-[ ] 2.2  $adtSession mit allen Metadaten
-[ ] 2.3  Install/Uninstall/Repair-Hooks gefuellt
-[ ] 2.4  Custom-Helpers in PSAppDeployToolkit.Extensions, nicht im Main
+[ ] 2.2  $adtSession with all metadata
+[ ] 2.3  Install/Uninstall/Repair hooks filled in
+[ ] 2.4  Custom helpers in PSAppDeployToolkit.Extensions, not in the main script
 
 Phase 3 - Pre-Flight
-[ ] 3.1  Encoding: HasBOM=True ODER NonAscii=0
+[ ] 3.1  Encoding: HasBOM=True OR NonAscii=0
 [ ] 3.2  ParseFile PARSE_OK
-[ ] 3.3  Launcher-Simulation gruen
-[ ] 3.4  Param-Block zu v4-Template synchron
-[ ] 3.5  Keine v3-Cmdlet-Reste
-[ ] 3.6  Keine Top-Level-Statements die werfen koennen
+[ ] 3.3  Launcher simulation green
+[ ] 3.4  Param block in sync with v4 template
+[ ] 3.5  No v3 cmdlet remnants
+[ ] 3.6  No top-level statements that can throw
 
-Phase 4 - Bauen
+Phase 4 - Build
 [ ] 4.1  IntuneWinAppUtil latest
-[ ] 4.2  -c / -s / -o korrekt, -o NICHT im -c
-[ ] 4.3  Inspektion: Detection.xml hat SetupFile=Invoke-AppDeployToolkit.exe
+[ ] 4.2  -c / -s / -o correct, -o NOT inside -c
+[ ] 4.3  Inspection: Detection.xml has SetupFile=Invoke-AppDeployToolkit.exe
 
-Phase 5 - Intune-Config
+Phase 5 - Intune config
 [ ] 5.1  App Info + Logo
-[ ] 5.2  Install/Uninstall-Command + Install Behavior=System
-[ ] 5.3  Return Codes komplett (inkl. 60001+60008=Failed)
+[ ] 5.2  Install/Uninstall command + Install Behavior=System
+[ ] 5.3  Return codes complete (incl. 60001+60008=Failed)
 [ ] 5.4  Requirements (OS, Arch, Disk, Memory)
-[ ] 5.5  Detection-Methode EINDEUTIG
-[ ] 5.6  Install time realitaetsnah
-[ ] 5.7  Assignments + Filter + Delivery-Opt
+[ ] 5.5  Detection method UNAMBIGUOUS
+[ ] 5.6  Install time realistic
+[ ] 5.7  Assignments + Filter + Delivery Opt
 
 Phase 6 - Test
-[ ] 6.1  Direct-Invoke auf DEV
-[ ] 6.2  Launcher-Invoke auf DEV
-[ ] 6.3  Psexec -s auf DEV
-[ ] 6.4  Testgruppen-Deploy -> PSADT-Log + Close-ADTSession Exit 0
+[ ] 6.1  Direct invoke on DEV
+[ ] 6.2  Launcher invoke on DEV
+[ ] 6.3  Psexec -s on DEV
+[ ] 6.4  Test-group deploy -> PSADT log + Close-ADTSession Exit 0
 
 Phase 7 - Rollout
 [ ] 7.1  Pilot (24-48h)
 [ ] 7.2  Production staged
-[ ] 7.3  GitHub-Release-Watch abonniert
+[ ] 7.3  GitHub release watch subscribed
 ```
 
 Only when ALL lines are green: production rollout.
@@ -821,14 +821,14 @@ Only when ALL lines are green: production rollout.
 
 ## Appendix F: Intune deployment dossier (upload template, to be filled in per app)
 
-Place this template as a Markdown file per app next to the `.intunewin` (e.g. `<AppName>-IntuneDossier.md`). Without a filled-in dossier: **no upload**. The values come from Phase 0.2/0.3.
+Place this template as a full HTML file per app next to the `.intunewin` (`Intune-Dossier.html`). Without a filled-in dossier: **no upload**. The values come from Phase 0.2/0.3.
 
 ### F.1 App information
 
 | Intune field | Value | Notes |
 |---|---|---|
 | **Name** | `<AppName> <Version>` | exactly as visible in the Company Portal; version incl. build if there are updates |
-| **Description** | see F.2 (Markdown block) | the first ~200 characters are the short preview in the CP |
+| **Description** | see F.2 (HTML block) | the first ~200 characters are the short preview in the CP |
 | **Publisher** | `<Hersteller>` | from Phase 0.2 (Adobe Inc., Oracle Corporation, ...) |
 | **App version** | `<Major.Minor.Build.Rev>` | exact file version |
 | **Category** | e.g. Business, Development, Productivity, Communication | for CP navigation |
@@ -841,42 +841,41 @@ Place this template as a Markdown file per app next to the `.intunewin` (e.g. `<
 | **Logo** | `<pkg>\Assets\AppIcon.png` | 256x256 PNG transparent |
 | **Role scope tags** | `<Default>` or custom | only with a delegated admin role structure |
 
-### F.2 Description Markdown template (Company Portal)
+### F.2 Description HTML template (Company Portal)
 
-Intune renders Markdown in the Company Portal. Copy the block 1:1, replace `<...>`.
+The Intune description field has an HTML editor and renders HTML in the Company Portal. Copy the block 1:1, replace `<...>`.
 
 (end-user output — language.dossier, default German)
 
-```markdown
-**<AppName>** ist <Ein-Satz-Zweck>.
+```html
+<p><strong>&lt;AppName&gt;</strong> ist &lt;Ein-Satz-Zweck&gt;.</p>
 
-<Zwei-bis-drei-Saetze-Nutzenbeschreibung fuer Endbenutzer. Was bekommen sie, wofuer brauchen sie das.>
+<p>&lt;Zwei-bis-drei-Sätze-Nutzenbeschreibung für Endbenutzer. Was bekommen sie, wofür brauchen sie das.&gt;</p>
 
-### Was du bekommst
+<p><strong>Was du bekommst</strong></p>
+<ul>
+  <li>&lt;Feature 1&gt;</li>
+  <li>&lt;Feature 2&gt;</li>
+  <li>&lt;Feature 3&gt;</li>
+  <li>&lt;ggf. Config / Branding&gt;</li>
+</ul>
 
-- <Feature 1>
-- <Feature 2>
-- <Feature 3>
-- <ggf. Config / Branding>
+<p><strong>Was du brauchst</strong></p>
+<ul>
+  <li>Windows 11 (oder Windows 10 22H2+)</li>
+  <li>~&lt;X&gt; GB freier Speicherplatz auf <code>C:</code></li>
+  <li>Ca. <strong>&lt;N&gt;-&lt;M&gt; Minuten</strong> Installationsdauer</li>
+  <li><em>&lt;ggf. Kein Neustart erforderlich / Neustart empfohlen&gt;</em></li>
+</ul>
 
-### Was du brauchst
+<p><strong>Nach der Installation</strong></p>
+<p>&lt;Was findet der User vor? Startmenü-Eintrag, Desktop-Shortcut, Config-Datei, Zugangsdaten?&gt;</p>
 
-- Windows 11 (oder Windows 10 22H2+)
-- ~<X> GB freier Speicherplatz auf `C:`
-- Ca. **<N>-<M> Minuten** Installationsdauer
-- *<ggf. Kein Neustart erforderlich / Neustart empfohlen>*
+<p><strong>Deinstallation</strong></p>
+<p>&lt;Was passiert bei Deinstall? Bleiben User-Daten, werden sie entfernt, was soll der User vorher sichern?&gt;</p>
 
-### Nach der Installation
-
-<Was findet der User vor? Startmenu-Eintrag, Desktop-Shortcut, Config-Datei, Zugangsdaten?>
-
-### Deinstallation
-
-<Was passiert bei Deinstall? Bleiben User-Daten, werden sie entfernt, was soll der User vorher sichern?>
-
-### Support
-
-Bei Problemen bitte ein Ticket beim **IT-Service-Desk** eroeffnen und - wenn moeglich - die Logdateien unter `C:\Windows\Logs\Software\` anhaengen.
+<p><strong>Support</strong></p>
+<p>Bei Problemen bitte ein Ticket beim <strong>IT-Service-Desk</strong> eröffnen und - wenn möglich - die Logdateien unter <code>C:\Windows\Logs\Software\</code> anhängen. Weitere Hinweise im <a href="&lt;support-portal-url&gt;">Support-Portal</a>.</p>
 ```
 
 Check: the first paragraph must also be readable on its own (200-character short preview).

--- a/scripts/Get-IntuneWinAppUtil.ps1
+++ b/scripts/Get-IntuneWinAppUtil.ps1
@@ -26,6 +26,11 @@ $tag = if ($latestTag) { $latestTag } else { 'v1.8.7' }
 try {
     New-Item (Split-Path $exe -Parent) -ItemType Directory -Force | Out-Null
     Invoke-WebRequest "https://github.com/$repo/raw/$tag/IntuneWinAppUtil.exe" -OutFile $exe
+    $fs = [System.IO.File]::OpenRead($exe); $hdr = New-Object byte[] 2; $null = $fs.Read($hdr, 0, 2); $fs.Close()
+    if (((Get-Item $exe).Length -lt 2) -or $hdr[0] -ne 0x4D -or $hdr[1] -ne 0x5A) {
+        Remove-Item $exe -Force -ErrorAction SilentlyContinue
+        throw "Downloaded file is not a valid executable (missing MZ header)."
+    }
     & (Join-Path $PSScriptRoot 'Set-PsadtConfig.ps1') -SkillRoot $SkillRoot -Updates @{ 'tooling.intuneWinAppUtilVersion' = $tag }
     return [pscustomobject]@{ Action='Downloaded'; Version=$tag; Path=$exe }
 } catch {

--- a/scripts/Get-IntuneWinAppUtil.ps1
+++ b/scripts/Get-IntuneWinAppUtil.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS  Ensures tools/IntuneWinAppUtil.exe is present and current vs the official MS repo.
+.OUTPUTS   PSCustomObject: Action(Downloaded|AlreadyCurrent|UpdateFailed), Version, Path
+#>
+[CmdletBinding()]
+param([string]$SkillRoot = (Split-Path $PSScriptRoot -Parent))
+$ErrorActionPreference = 'Stop'
+$repo = 'microsoft/Microsoft-Win32-Content-Prep-Tool'
+$exe  = Join-Path $SkillRoot 'tools/IntuneWinAppUtil.exe'
+$configPath = Join-Path $SkillRoot 'config.json'
+
+$installedVersion = $null
+if (Test-Path $configPath) {
+    $cfg = Get-Content $configPath -Raw | ConvertFrom-Json
+    $installedVersion = $cfg.tooling.intuneWinAppUtilVersion
+}
+
+$latestTag = $null
+try { $latestTag = (Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest").tag_name } catch { }
+
+if ((Test-Path $exe) -and $latestTag -and $installedVersion -eq $latestTag) {
+    return [pscustomobject]@{ Action='AlreadyCurrent'; Version=$latestTag; Path=$exe }
+}
+
+$tag = if ($latestTag) { $latestTag } else { 'v1.8.7' }
+try {
+    New-Item (Split-Path $exe -Parent) -ItemType Directory -Force | Out-Null
+    Invoke-WebRequest "https://github.com/$repo/raw/$tag/IntuneWinAppUtil.exe" -OutFile $exe
+    & (Join-Path $PSScriptRoot 'Set-PsadtConfig.ps1') -SkillRoot $SkillRoot -Updates @{ 'tooling.intuneWinAppUtilVersion' = $tag }
+    return [pscustomobject]@{ Action='Downloaded'; Version=$tag; Path=$exe }
+} catch {
+    if (Test-Path $exe) { return [pscustomobject]@{ Action='AlreadyCurrent'; Version=$installedVersion; Path=$exe } }
+    return [pscustomobject]@{ Action='UpdateFailed'; Version=$null; Path=$exe; Error="$_" }
+}

--- a/scripts/Get-PsadtConfig.ps1
+++ b/scripts/Get-PsadtConfig.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS  Reads the PSADT skill config and reports any missing required fields.
+.OUTPUTS   PSCustomObject: Exists(bool), Config(object|null), Missing(string[]), Path(string)
+#>
+[CmdletBinding()]
+param([string]$SkillRoot = (Split-Path $PSScriptRoot -Parent))
+
+$configPath = Join-Path $SkillRoot 'config.json'
+$required = @(
+    'paths.packageRoot','paths.outputRoot','paths.intuneWinAppUtil',
+    'language.script','language.dossier','author.person','author.company'
+)
+function Get-ByPath($obj, [string]$path) {
+    $cur = $obj
+    foreach ($seg in ($path -split '\.')) {
+        if ($null -eq $cur) { return $null }
+        $cur = $cur.$seg
+    }
+    return $cur
+}
+
+if (-not (Test-Path $configPath)) {
+    return [pscustomobject]@{ Exists = $false; Config = $null; Missing = $required; Path = $configPath }
+}
+
+$cfg = Get-Content $configPath -Raw | ConvertFrom-Json
+$missing = [System.Collections.Generic.List[string]]::new()
+foreach ($key in $required) {
+    if ([string]::IsNullOrWhiteSpace([string](Get-ByPath $cfg $key))) { $missing.Add($key) }
+}
+if ($cfg.intune -and $cfg.intune.uploadEnabled) {
+    foreach ($f in 'tenantId','clientId') {
+        if ([string]::IsNullOrWhiteSpace([string]$cfg.intune.$f)) { $missing.Add("intune.$f") }
+    }
+    $ref = if ($cfg.intune.secretRef) { $cfg.intune.secretRef } else { 'secret.dpapi' }
+    if (-not (Test-Path (Join-Path $SkillRoot $ref))) { $missing.Add('intune.secret') }
+}
+[pscustomobject]@{ Exists = $true; Config = $cfg; Missing = $missing.ToArray(); Path = $configPath }

--- a/scripts/Get-PsadtModule.ps1
+++ b/scripts/Get-PsadtModule.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS  Ensures the PSAppDeployToolkit module is installed; never a manual hurdle.
+.OUTPUTS   PSCustomObject: Action(Installed|AlreadyCurrent|UpdateAvailable|InstallFailed), Installed, Latest
+#>
+[CmdletBinding()]
+param([string]$SkillRoot = (Split-Path $PSScriptRoot -Parent))
+$ErrorActionPreference = 'Stop'
+$name = 'PSAppDeployToolkit'
+
+$local = Get-Module -ListAvailable -Name $name | Sort-Object Version -Descending | Select-Object -First 1
+$latest = $null
+try { $latest = Find-Module -Name $name -ErrorAction Stop } catch { }
+
+if (-not $local) {
+    try {
+        Install-Module -Name $name -Scope CurrentUser -Force -AllowClobber
+        $local = Get-Module -ListAvailable -Name $name | Sort-Object Version -Descending | Select-Object -First 1
+        return [pscustomobject]@{ Action='Installed'; Installed="$($local.Version)"; Latest="$($latest.Version)" }
+    } catch {
+        return [pscustomobject]@{ Action='InstallFailed'; Installed=$null; Latest="$($latest.Version)"; Error="$_" }
+    }
+}
+if ($latest -and $latest.Version -gt $local.Version) {
+    return [pscustomobject]@{ Action='UpdateAvailable'; Installed="$($local.Version)"; Latest="$($latest.Version)" }
+}
+[pscustomobject]@{ Action='AlreadyCurrent'; Installed="$($local.Version)"; Latest="$($latest.Version)" }

--- a/scripts/Get-PsadtModule.ps1
+++ b/scripts/Get-PsadtModule.ps1
@@ -15,7 +15,11 @@ if (-not $local) {
     try {
         Install-Module -Name $name -Scope CurrentUser -Force -AllowClobber
         $local = Get-Module -ListAvailable -Name $name | Sort-Object Version -Descending | Select-Object -First 1
-        return [pscustomobject]@{ Action='Installed'; Installed="$($local.Version)"; Latest="$($latest.Version)" }
+        $installed = if ($local) { "$($local.Version)" } elseif ($latest) { "$($latest.Version)" } else { $null }
+        if (-not $installed) {
+            return [pscustomobject]@{ Action='InstallFailed'; Installed=$null; Latest="$($latest.Version)"; Error='Module not found after install.' }
+        }
+        return [pscustomobject]@{ Action='Installed'; Installed=$installed; Latest="$($latest.Version)" }
     } catch {
         return [pscustomobject]@{ Action='InstallFailed'; Installed=$null; Latest="$($latest.Version)"; Error="$_" }
     }

--- a/scripts/Set-PsadtConfig.ps1
+++ b/scripts/Set-PsadtConfig.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS  Creates/updates config.json (partial merge) and DPAPI-encrypts the client secret.
+.PARAMETER Updates  Hashtable of dotted-path -> value (e.g. @{ 'paths.packageRoot'='c:\p' }).
+.PARAMETER Secret   SecureString; DPAPI-encrypted (CurrentUser) to secret.dpapi. Never logged/returned.
+#>
+[CmdletBinding()]
+param(
+    [string]$SkillRoot = (Split-Path $PSScriptRoot -Parent),
+    [hashtable]$Updates = @{},
+    [System.Security.SecureString]$Secret
+)
+
+$configPath = Join-Path $SkillRoot 'config.json'
+function ConvertTo-HashtableDeep($obj) {
+    if ($obj -is [System.Management.Automation.PSCustomObject]) {
+        $h = @{}
+        foreach ($p in $obj.PSObject.Properties) { $h[$p.Name] = ConvertTo-HashtableDeep $p.Value }
+        return $h
+    }
+    return $obj
+}
+$config = if (Test-Path $configPath) {
+    ConvertTo-HashtableDeep (Get-Content $configPath -Raw | ConvertFrom-Json)
+} else { @{ version = 1 } }
+if (-not $config.ContainsKey('version')) { $config['version'] = 1 }
+
+foreach ($key in $Updates.Keys) {
+    $segs = $key -split '\.'
+    $node = $config
+    for ($i = 0; $i -lt $segs.Count - 1; $i++) {
+        if (-not ($node[$segs[$i]] -is [hashtable])) { $node[$segs[$i]] = @{} }
+        $node = $node[$segs[$i]]
+    }
+    $node[$segs[-1]] = $Updates[$key]
+}
+
+$config | ConvertTo-Json -Depth 8 | Set-Content -Path $configPath -Encoding UTF8
+
+if ($Secret) {
+    $enc = ConvertFrom-SecureString $Secret
+    Set-Content -Path (Join-Path $SkillRoot 'secret.dpapi') -Value $enc -Encoding ASCII -NoNewline
+}

--- a/tests/Get-IntuneWinAppUtil.Tests.ps1
+++ b/tests/Get-IntuneWinAppUtil.Tests.ps1
@@ -26,4 +26,19 @@ Describe 'Get-IntuneWinAppUtil' {
         Should -Invoke Invoke-WebRequest -Times 0
         $r.Action | Should -Be 'AlreadyCurrent'
     }
+
+    It 'falls back to a known tag when the release API is unreachable (offline)' {
+        Mock -CommandName Invoke-RestMethod -MockWith { throw 'no network' }
+        Mock -CommandName Invoke-WebRequest -MockWith { Set-Content (Join-Path $script:root 'tools/IntuneWinAppUtil.exe') 'MZ' }
+        $r = & $script:run
+        $r.Action  | Should -Be 'Downloaded'
+        $r.Version | Should -Be 'v1.8.7'
+    }
+
+    It 'returns UpdateFailed when the download fails and no exe exists' {
+        Mock -CommandName Invoke-RestMethod -MockWith { @{ tag_name = 'v1.8.7' } }
+        Mock -CommandName Invoke-WebRequest -MockWith { throw 'download failed' }
+        $r = & $script:run
+        $r.Action | Should -Be 'UpdateFailed'
+    }
 }

--- a/tests/Get-IntuneWinAppUtil.Tests.ps1
+++ b/tests/Get-IntuneWinAppUtil.Tests.ps1
@@ -1,0 +1,29 @@
+BeforeAll { . "$PSScriptRoot/_helpers.ps1" }
+Describe 'Get-IntuneWinAppUtil' {
+    BeforeEach {
+        $script:root = New-TempSkillRoot
+        $script:run  = { . (Join-Path $script:root 'scripts/Get-IntuneWinAppUtil.ps1') -SkillRoot $script:root }
+    }
+    AfterEach { Remove-TempSkillRoot $script:root }
+
+    It 'downloads the exe when missing and records version' {
+        Mock -CommandName Invoke-RestMethod -MockWith { @{ tag_name = 'v1.8.7' } }
+        Mock -CommandName Invoke-WebRequest -MockWith { Set-Content (Join-Path $script:root 'tools/IntuneWinAppUtil.exe') 'MZ' }
+        $r = & $script:run
+        Should -Invoke Invoke-WebRequest -Times 1
+        $r.Action  | Should -Be 'Downloaded'
+        $r.Version | Should -Be 'v1.8.7'
+        (Test-Path (Join-Path $script:root 'tools/IntuneWinAppUtil.exe')) | Should -BeTrue
+    }
+
+    It 'is a no-op when present and version matches config' {
+        Set-Content (Join-Path $script:root 'tools/IntuneWinAppUtil.exe') 'MZ'
+        @{ version=1; tooling=@{ intuneWinAppUtilVersion='v1.8.7' } } |
+            ConvertTo-Json -Depth 5 | Set-Content (Join-Path $script:root 'config.json')
+        Mock -CommandName Invoke-RestMethod -MockWith { @{ tag_name = 'v1.8.7' } }
+        Mock -CommandName Invoke-WebRequest -MockWith { }
+        $r = & $script:run
+        Should -Invoke Invoke-WebRequest -Times 0
+        $r.Action | Should -Be 'AlreadyCurrent'
+    }
+}

--- a/tests/Get-PsadtConfig.Tests.ps1
+++ b/tests/Get-PsadtConfig.Tests.ps1
@@ -1,0 +1,40 @@
+BeforeAll { . "$PSScriptRoot/_helpers.ps1" }
+Describe 'Get-PsadtConfig' {
+    BeforeEach {
+        $script:root = New-TempSkillRoot
+        $script:run  = { & (Join-Path $script:root 'scripts/Get-PsadtConfig.ps1') -SkillRoot $script:root }
+    }
+    AfterEach  { Remove-TempSkillRoot $script:root }
+
+    It 'reports Exists=$false and all required fields missing when no config' {
+        $r = & $script:run
+        $r.Exists | Should -BeFalse
+        $r.Missing | Should -Contain 'paths.packageRoot'
+        $r.Missing | Should -Contain 'author.person'
+    }
+
+    It 'returns Exists=$true and empty Missing for a complete config' {
+        @{
+            version=1
+            paths=@{ packageRoot='c:\p'; outputRoot='c:\o'; intuneWinAppUtil='c:\t\x.exe' }
+            language=@{ script='EN'; dossier='DE' }
+            author=@{ person='Pat'; company='PHAT' }
+        } | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $script:root 'config.json')
+        $r = & $script:run
+        $r.Exists | Should -BeTrue
+        $r.Missing | Should -BeNullOrEmpty
+    }
+
+    It 'requires intune fields only when uploadEnabled is true' {
+        @{
+            version=1
+            paths=@{ packageRoot='c:\p'; outputRoot='c:\o'; intuneWinAppUtil='c:\t\x.exe' }
+            language=@{ script='EN'; dossier='DE' }
+            author=@{ person='Pat'; company='PHAT' }
+            intune=@{ uploadEnabled=$true; secretRef='secret.dpapi' }
+        } | ConvertTo-Json -Depth 6 | Set-Content (Join-Path $script:root 'config.json')
+        $r = & $script:run
+        $r.Missing | Should -Contain 'intune.tenantId'
+        $r.Missing | Should -Contain 'intune.secret'
+    }
+}

--- a/tests/Get-PsadtModule.Tests.ps1
+++ b/tests/Get-PsadtModule.Tests.ps1
@@ -1,0 +1,39 @@
+BeforeAll {
+    . "$PSScriptRoot/_helpers.ps1"
+    Import-Module PowerShellGet -MinimumVersion 2.0 -ErrorAction Stop
+}
+Describe 'Get-PsadtModule' {
+    BeforeEach {
+        $script:root = New-TempSkillRoot
+        $script:run  = { . (Join-Path $script:root 'scripts/Get-PsadtModule.ps1') -SkillRoot $script:root }
+    }
+    AfterEach { Remove-TempSkillRoot $script:root }
+
+    It 'installs the module when none is present' {
+        Mock -CommandName Get-Module     -MockWith { @() }
+        Mock -CommandName Install-Module -MockWith { }
+        Mock -CommandName Find-Module    -MockWith { [pscustomobject]@{ Version = [version]'4.1.0' } }
+        $r = & $script:run
+        Should -Invoke Install-Module -Times 1
+        $r.Action | Should -Be 'Installed'
+    }
+
+    It 'does not install when a usable version exists' {
+        Mock -CommandName Get-Module     -MockWith { [pscustomobject]@{ Version = [version]'4.1.0' } }
+        Mock -CommandName Install-Module -MockWith { }
+        Mock -CommandName Find-Module    -MockWith { [pscustomobject]@{ Version = [version]'4.1.0' } }
+        $r = & $script:run
+        Should -Invoke Install-Module -Times 0
+        $r.Action | Should -Be 'AlreadyCurrent'
+    }
+
+    It 'reports UpdateAvailable when newer exists but does not auto-update' {
+        Mock -CommandName Get-Module     -MockWith { [pscustomobject]@{ Version = [version]'4.0.0' } }
+        Mock -CommandName Install-Module -MockWith { }
+        Mock -CommandName Find-Module    -MockWith { [pscustomobject]@{ Version = [version]'4.1.0' } }
+        $r = & $script:run
+        Should -Invoke Install-Module -Times 0
+        $r.Action | Should -Be 'UpdateAvailable'
+        $r.Latest | Should -Be '4.1.0'
+    }
+}

--- a/tests/Get-PsadtModule.Tests.ps1
+++ b/tests/Get-PsadtModule.Tests.ps1
@@ -15,7 +15,8 @@ Describe 'Get-PsadtModule' {
         Mock -CommandName Find-Module    -MockWith { [pscustomobject]@{ Version = [version]'4.1.0' } }
         $r = & $script:run
         Should -Invoke Install-Module -Times 1
-        $r.Action | Should -Be 'Installed'
+        $r.Action    | Should -Be 'Installed'
+        $r.Installed | Should -Not -BeNullOrEmpty
     }
 
     It 'does not install when a usable version exists' {

--- a/tests/Run-All.ps1
+++ b/tests/Run-All.ps1
@@ -1,0 +1,1 @@
+Invoke-Pester -Path "$PSScriptRoot" -Output Detailed -CI

--- a/tests/Set-PsadtConfig.Tests.ps1
+++ b/tests/Set-PsadtConfig.Tests.ps1
@@ -1,0 +1,35 @@
+BeforeAll { . "$PSScriptRoot/_helpers.ps1" }
+Describe 'Set-PsadtConfig' {
+    BeforeEach {
+        $script:root = New-TempSkillRoot
+        $script:set  = { param($h) & (Join-Path $script:root 'scripts/Set-PsadtConfig.ps1') -SkillRoot $script:root @h }
+    }
+    AfterEach { Remove-TempSkillRoot $script:root }
+
+    It 'creates config.json with nested values' {
+        & $script:set @{ Updates = @{ 'paths.packageRoot'='c:\p'; 'author.person'='Pat' } }
+        $cfg = Get-Content (Join-Path $script:root 'config.json') -Raw | ConvertFrom-Json
+        $cfg.paths.packageRoot | Should -Be 'c:\p'
+        $cfg.author.person     | Should -Be 'Pat'
+        $cfg.version           | Should -Be 1
+    }
+
+    It 'merges into an existing config without dropping prior keys' {
+        & $script:set @{ Updates = @{ 'paths.packageRoot'='c:\p' } }
+        & $script:set @{ Updates = @{ 'author.company'='PHAT' } }
+        $cfg = Get-Content (Join-Path $script:root 'config.json') -Raw | ConvertFrom-Json
+        $cfg.paths.packageRoot | Should -Be 'c:\p'
+        $cfg.author.company    | Should -Be 'PHAT'
+    }
+
+    It 'DPAPI-encrypts the secret to secret.dpapi and never to config.json' {
+        $sec = ConvertTo-SecureString 'p@ss-w0rd!' -AsPlainText -Force
+        & $script:set @{ Secret = $sec }
+        $blob = Get-Content (Join-Path $script:root 'secret.dpapi') -Raw
+        $blob | Should -Not -BeNullOrEmpty
+        $blob | Should -Not -Match 'p@ss-w0rd'
+        (Get-Content (Join-Path $script:root 'config.json') -Raw) | Should -Not -Match 'p@ss-w0rd'
+        $back = ConvertTo-SecureString $blob
+        [System.Net.NetworkCredential]::new('', $back).Password | Should -Be 'p@ss-w0rd!'
+    }
+}

--- a/tests/_helpers.ps1
+++ b/tests/_helpers.ps1
@@ -1,0 +1,13 @@
+function New-TempSkillRoot {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("psadtskill_" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $root 'scripts')    -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $root 'tools')      -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $root 'references') -Force | Out-Null
+    $srcScripts = Join-Path $PSScriptRoot '..\scripts'
+    if (Test-Path $srcScripts) { Copy-Item "$srcScripts\*" (Join-Path $root 'scripts') -Force }
+    return $root
+}
+function Remove-TempSkillRoot([string]$Path) {
+    if ($Path -and (Test-Path $Path)) { Remove-Item $Path -Recurse -Force -ErrorAction SilentlyContinue }
+}


### PR DESCRIPTION
## Summary

Implements the first version of the skill-setup work per the
[design spec](docs/superpowers/specs/2026-06-04-psadt-skill-setup-design.md) and
[implementation plan](docs/superpowers/plans/2026-06-04-psadt-skill-setup.md).

**In scope (this version):**
- **First-run setup (Phase 0)** in `SKILL.md` + a `config.json` schema, with the setup wizard asking only missing values via clickable options.
- **Helper scripts** (Pester-tested):
  - `Get-PsadtConfig.ps1` — read config + report missing fields
  - `Set-PsadtConfig.ps1` — deep-merge config + DPAPI-encrypt secret (CurrentUser)
  - `Get-PsadtModule.ps1` — self-heal the PSAppDeployToolkit module (install from PSGallery if missing)
  - `Get-IntuneWinAppUtil.ps1` — auto-download + version-check the content-prep tool (vs official MS repo), validates the downloaded exe (MZ header)
- **HTML deliverables** — dossier convention switched from Markdown to `Intune-Dossier.html`; guide Appendix F + anti-patterns updated to match.
- **English translation** of `SKILL.md` and the reference guide (dossier OUTPUT stays in `language.dossier`, default German).
- Reference guide now bundled at `references/PSADTv4-Deployment-Guide.md`; `SKILL.md` points there (self-contained).

**Deferred to a future release (NOT in this PR):** the optional direct Intune upload via Microsoft Graph (Test-PsadtSetup, Invoke-IntuneWin32Upload, app-registration). README and SKILL.md mark it as planned; for now upload the `.intunewin` manually in the Admin Center.

## Tests
`Invoke-Pester -Path tests` → **13/13 passing** (Pester 5.7.1). Covers missing-field detection, conditional intune gating, deep-merge, DPAPI round-trip (secret never in config.json/blob), module install/skip/update branches, and tool download/no-op/offline-fallback/failure paths.

## Reviews
Two-stage subagent review per task during implementation + a final branch review (verdict GO). Findings fixed: null-post-install guard (Get-PsadtModule), downloaded-exe validation (Get-IntuneWinAppUtil), guide Appendix F HTML alignment, Appendix E translation.

## Notes
- Machine-local `config.json`, `secret.dpapi`, `tools/` are gitignored — none committed.
- **Post-merge action:** install into `~/.claude/skills/psadt-deploy/` (SKILL.md + scripts/ + references/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)