### PR TITLE
Automated SYSTEM-context test loop (Invoke-CommandAs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
   <img src="https://img.shields.io/badge/Claude%20Code-Skill-d97757?style=flat-square" alt="Claude Code Skill" />
 </p>
 
+<p align="center"><sub><a href="#roadmap">Roadmap</a> · <a href="#changelog">Changelog</a></sub></p>
+
 ---
 
 ## What is this?
@@ -54,6 +56,10 @@ description until a task makes it relevant, then the full body loads on demand.
 - **Troubleshooting** — decodes Intune error/HRESULT codes (e.g. `0x80070001`), maps symptoms to root
   causes, and triages the right logs (AppWorkload.log, PSADT session log).
 - **Start Menu only** — creates Start Menu entries and removes stray desktop icons; keeps the desktop clean.
+- **Automated SYSTEM test loop** *(opt-in)* — before packaging, installs/uninstalls/reinstalls the package
+  as the **SYSTEM** account (via `Invoke-CommandAs`, mirroring the Intune Management Extension), evaluates
+  logs + detection, and auto-fixes until green or a max-iteration cap. Runs locally and needs an elevated
+  session; recommended on a VM/snapshot.
 
 > Planned features (direct Intune upload, GitHub package sync) live in the [Roadmap](#roadmap).
 
@@ -64,6 +70,9 @@ description until a task makes it relevant, then the full body loads on demand.
   automatically from the PowerShell Gallery if missing)*
 - [Microsoft Win32 Content Prep Tool](https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool)
   *(the skill provisions this automatically)*
+- For the optional **automated SYSTEM test loop**: an **elevated** PowerShell session; the
+  [`Invoke-CommandAs`](https://github.com/mkellerman/Invoke-CommandAs) module is installed automatically
+  from the PowerShell Gallery
 - *(Future release only)* For the optional direct upload: an Entra app registration with the Graph
   **application** permission `DeviceManagementApps.ReadWrite.All` (admin consent granted)
 
@@ -158,4 +167,25 @@ configurable per machine.
 
 - [PSAppDeployToolkit](https://github.com/PSAppDeployToolkit/PSAppDeployToolkit)
 - [Microsoft Win32 Content Prep Tool](https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool)
+- [`Invoke-CommandAs`](https://github.com/mkellerman/Invoke-CommandAs)
 - README structure inspired by [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills)
+
+## Changelog
+
+Notable changes to the skill. Newest first.
+
+### 0.2.0
+- **Automated SYSTEM test loop** (`scripts/Invoke-PsadtSystemTest.ps1`, Phase 5.5): install → uninstall →
+  reinstall the package as the SYSTEM account via `Invoke-CommandAs`, with agent-driven auto-fix until
+  green or a max-iteration cap. Opt-in; elevated session required.
+- Phase 8 now prefers `Invoke-CommandAs -AsSystem` for SYSTEM-context testing (PsExec kept as a fallback).
+
+### 0.1.0
+- Initial release: guided PSADT v4 → Intune Win32 lifecycle (intake, autonomous research, scaffolding, all
+  three deployment types, pre-flight checks, packaging, dossier + logo, guided testing, troubleshooting).
+- First-run setup writing a machine-local `config.json` (paths, language, author).
+- Self-healing prerequisites: PSAppDeployToolkit module (PSGallery) and `IntuneWinAppUtil.exe`
+  (auto-download + version check).
+- HTML dossier document with a Markdown app-description block (the Intune description field is
+  Markdown-only).
+- English skill + reference guide; MIT licensed.

--- a/SKILL.md
+++ b/SKILL.md
@@ -260,6 +260,33 @@ $ast.EndBlock.Statements | Where-Object { $_ -isnot [System.Management.Automatio
     ForEach-Object { "L$($_.Extent.StartLineNumber): $($_.GetType().Name)" }
 ```
 
+### 5.5 Automated SYSTEM test loop (opt-in, BEFORE packaging)
+
+Validate the package's Install/Uninstall scripts in a real **SYSTEM** context (mirroring the Intune
+Management Extension) BEFORE packing, so bugs are caught early. Runs on the package **source folder** (no
+`.intunewin` needed yet — fixes to the `.ps1` take effect on the next run, and you pack the validated
+scripts afterward). Requires an **elevated** PowerShell session.
+
+Only run when `test.systemTestEnabled` is true OR the user opts in for this package.
+
+**Hands:** `scripts/Invoke-PsadtSystemTest.ps1` runs ONE action as SYSTEM (via the `Invoke-CommandAs`
+module, self-healed from PSGallery) and returns
+`{ DeploymentType, ExitCode, Success, DetectionState, LogPath, LogTail, ErrorLines, Elevated }`. It fixes
+nothing — YOU (the agent) drive the loop and apply fixes between runs.
+
+**Safety (this installs the REAL software on THIS machine as SYSTEM):**
+- Before the FIRST install, confirm via `AskUserQuestion` and recommend a VM/snapshot.
+- Hard cap `test.maxIterations` (default 5) — never loop forever.
+- After a green run, leave the machine in `test.endState` (default `uninstalled`, leftover-clean).
+- Keep each iteration's PSADT log in the output folder for an audit trail.
+
+**Loop (max `test.maxIterations`):**
+1. **Install:** `pwsh scripts/Invoke-PsadtSystemTest.ps1 -PackagePath <pkg> -DeploymentType Install -DetectionScript <detect>` (elevated). If not `Success`: read `LogTail`/`ErrorLines`, map to a root cause via the Troubleshooting quick-reference + guide Appendix A, fix `Install-ADTDeployment` (or Extensions), re-run.
+2. **Uninstall:** run with `-DeploymentType Uninstall`. Verify `DetectionState = not-installed` AND the leftover checks (services, scheduled tasks, app registry key, install dir, firewall rules; neighbour products of the same vendor still present). On failure: fix `Uninstall-ADTDeployment`, re-run.
+3. **Reinstall:** run `Install` again; verify installed. On failure: fix, re-run.
+4. **Converged** (all three green) → leave the machine per `test.endState`, then proceed to Packaging (Phase 6) with the validated scripts.
+5. **Cap reached** without convergence → STOP, present the diagnosis (last error, log tail, what was tried) and hand back to the user. Never loop forever.
+
 ### 6. Packaging with IntuneWinAppUtil
 
 **Tool path and version are config-driven** (`paths.intuneWinAppUtil`) and are provisioned and kept current by `scripts/Get-IntuneWinAppUtil.ps1` (the inline download below stays as a manual fallback).
@@ -364,7 +391,7 @@ On a DEV VM in this order. After each successful install comes the uninstall tes
 **Install cycle:**
 1. `.\Invoke-AppDeployToolkit.ps1 -DeploymentType Install -DeployMode Silent` (smoke test)
 2. `.\Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent` (launcher acid test)
-3. `psexec -s cmd /c "cd /d <pkg> && Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent"` (SYSTEM context; PsExec: https://learn.microsoft.com/en-us/sysinternals/downloads/psexec)
+3. SYSTEM context: preferred is `scripts/Invoke-PsadtSystemTest.ps1` (uses the `Invoke-CommandAs` module, returns a structured result; see Phase 5.5 for the automated loop). Fallback: `psexec -s cmd /c "cd /d <pkg> && Invoke-AppDeployToolkit.exe -DeploymentType Install -DeployMode Silent"` (PsExec: https://learn.microsoft.com/en-us/sysinternals/downloads/psexec)
 
 **Uninstall cycle (on the same VM, app must be installed):**
 4. `.\Invoke-AppDeployToolkit.exe -DeploymentType Uninstall -DeployMode Silent`

--- a/scripts/Invoke-PsadtSystemTest.ps1
+++ b/scripts/Invoke-PsadtSystemTest.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS  Runs ONE PSADT deployment action as the SYSTEM account (via Invoke-CommandAs) and reports structured facts.
+.DESCRIPTION
+  Executes Invoke-AppDeployToolkit.exe -DeploymentType <X> -DeployMode Silent as SYSTEM, optionally runs a
+  detection script in the same SYSTEM context, reads the fresh PSADT session log, and returns a structured
+  result. Performs ONE action and decides nothing about fixes - the caller (skill/agent) drives the loop.
+.OUTPUTS PSCustomObject: DeploymentType, ExitCode, Success, DetectionState, LogPath, LogTail, ErrorLines, Elevated
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$PackagePath,
+    [Parameter(Mandatory)][ValidateSet('Install','Uninstall','Repair')][string]$DeploymentType,
+    [string]$DetectionScript,
+    [int[]]$SuccessExitCodes = @(0, 1707, 3010, 1641),
+    [string]$LogDirectory = 'C:\Windows\Logs\Software',
+    [bool]$IsElevated = (([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)),
+    [string]$SkillRoot = (Split-Path $PSScriptRoot -Parent)
+)
+$ErrorActionPreference = 'Stop'
+
+# 1. Elevation guard - creating a SYSTEM scheduled task needs admin
+if (-not $IsElevated) {
+    throw "Invoke-PsadtSystemTest must run in an ELEVATED PowerShell session (SYSTEM scheduled task creation requires admin). Re-run as Administrator."
+}
+
+# 2. Ensure the Invoke-CommandAs module is present (self-heal from PSGallery)
+if (-not (Get-Module -ListAvailable -Name Invoke-CommandAs)) {
+    Install-Module -Name Invoke-CommandAs -Scope CurrentUser -Force -AllowClobber
+}
+Import-Module Invoke-CommandAs -ErrorAction SilentlyContinue
+
+$exe = Join-Path $PackagePath 'Invoke-AppDeployToolkit.exe'
+
+# 3. Run the launcher (and optional detection) as SYSTEM in one context
+$sb = {
+    param($Exe, $Dt, $Detect)
+    $deployOut  = & $Exe -DeploymentType $Dt -DeployMode Silent 2>&1 | Out-String
+    $deployExit = $LASTEXITCODE
+    $detExit = $null; $detOut = $null
+    if ($Detect) {
+        $detOut  = & $Detect 2>&1 | Out-String
+        $detExit = $LASTEXITCODE
+    }
+    [pscustomobject]@{ DeployExitCode = $deployExit; DeployOutput = $deployOut; DetectExitCode = $detExit; DetectOutput = $detOut }
+}
+$run = Invoke-CommandAs -AsSystem -ScriptBlock $sb -ArgumentList $exe, $DeploymentType, $DetectionScript
+
+# 4. Locate + read the fresh PSADT session log
+$log = $null
+if (Test-Path $LogDirectory) {
+    $log = Get-ChildItem -Path $LogDirectory -Filter "*PSAppDeployToolkit_$DeploymentType.log" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
+$logPath = if ($log) { $log.FullName } else { $null }
+$logTail = if ($logPath) { (Get-Content $logPath -Tail 40) -join "`n" } else { '' }
+$errorLines = @()
+if ($logTail) { $errorLines = @($logTail -split "`n" | Where-Object { $_ -match '\[Error\]|ERROR|Exception' }) }
+
+# 5. Interpret detection (installed = exit 0 AND non-empty stdout, per Intune custom-detection contract)
+$state = 'unknown'
+if ($DetectionScript) {
+    $installed = ($run.DetectExitCode -eq 0) -and (-not [string]::IsNullOrWhiteSpace([string]$run.DetectOutput))
+    $state = if ($installed) { 'installed' } else { 'not-installed' }
+}
+
+# 6. Success per action
+$exitOk  = $SuccessExitCodes -contains [int]$run.DeployExitCode
+$success = switch ($DeploymentType) {
+    'Uninstall' { $exitOk -and ( -not $DetectionScript -or $state -eq 'not-installed' ) }
+    default     { $exitOk -and ( -not $DetectionScript -or $state -eq 'installed' ) }
+}
+
+[pscustomobject]@{
+    DeploymentType = $DeploymentType
+    ExitCode       = [int]$run.DeployExitCode
+    Success        = [bool]$success
+    DetectionState = $state
+    LogPath        = $logPath
+    LogTail        = $logTail
+    ErrorLines     = $errorLines
+    Elevated       = $true
+}

--- a/tests/Invoke-PsadtSystemTest.Tests.ps1
+++ b/tests/Invoke-PsadtSystemTest.Tests.ps1
@@ -1,0 +1,66 @@
+BeforeAll {
+    . "$PSScriptRoot/_helpers.ps1"
+    Import-Module PowerShellGet -ErrorAction SilentlyContinue
+    function Invoke-CommandAs { param([switch]$AsSystem, $ScriptBlock, $ArgumentList) }  # stub so Mock can bind
+}
+Describe 'Invoke-PsadtSystemTest' {
+    BeforeEach {
+        $script:root   = New-TempSkillRoot
+        $script:logdir = Join-Path $script:root 'logs'; New-Item $script:logdir -ItemType Directory -Force | Out-Null
+        $script:pkg    = Join-Path $script:root 'pkg';  New-Item $script:pkg    -ItemType Directory -Force | Out-Null
+        Set-Content (Join-Path $script:pkg 'Invoke-AppDeployToolkit.exe') 'stub'
+        $script:invoke = {
+            param($extra)
+            $p = @{ PackagePath = $script:pkg; LogDirectory = $script:logdir; IsElevated = $true; SkillRoot = $script:root } + $extra
+            . (Join-Path $script:root 'scripts/Invoke-PsadtSystemTest.ps1') @p
+        }
+    }
+    AfterEach { Remove-TempSkillRoot $script:root }
+
+    It 'throws when not elevated' {
+        { . (Join-Path $script:root 'scripts/Invoke-PsadtSystemTest.ps1') -PackagePath $script:pkg -DeploymentType Install -IsElevated $false } |
+            Should -Throw -ExpectedMessage '*ELEVATED*'
+    }
+
+    It 'self-heals the Invoke-CommandAs module when missing' {
+        Mock Get-Module -MockWith { @() }
+        Mock Install-Module -MockWith { }
+        Mock Import-Module -MockWith { }
+        Mock Invoke-CommandAs -MockWith { [pscustomobject]@{ DeployExitCode=0; DeployOutput='ok'; DetectExitCode=$null; DetectOutput=$null } }
+        & $script:invoke @{ DeploymentType = 'Install' }
+        Should -Invoke Install-Module -Times 1
+    }
+
+    It 'reports Success + installed for a clean install with detection' {
+        Mock Get-Module -MockWith { [pscustomobject]@{ Name='Invoke-CommandAs' } }
+        Mock Import-Module -MockWith { }
+        Mock Invoke-CommandAs -MockWith { [pscustomobject]@{ DeployExitCode=0; DeployOutput='ok'; DetectExitCode=0; DetectOutput='Detected v1' } }
+        Set-Content (Join-Path $script:logdir 'App_PSAppDeployToolkit_Install.log') "Installation complete`n[Info] done"
+        $r = & $script:invoke @{ DeploymentType='Install'; DetectionScript='C:\det.ps1' }
+        $r.Success        | Should -BeTrue
+        $r.DetectionState | Should -Be 'installed'
+        $r.ExitCode       | Should -Be 0
+        $r.LogPath        | Should -Not -BeNullOrEmpty
+    }
+
+    It 'reports failure + error lines for a bad install' {
+        Mock Get-Module -MockWith { [pscustomobject]@{ Name='Invoke-CommandAs' } }
+        Mock Import-Module -MockWith { }
+        Mock Invoke-CommandAs -MockWith { [pscustomobject]@{ DeployExitCode=1; DeployOutput='boom'; DetectExitCode=1; DetectOutput='' } }
+        Set-Content (Join-Path $script:logdir 'App_PSAppDeployToolkit_Install.log') "starting`n[Error] something failed"
+        $r = & $script:invoke @{ DeploymentType='Install'; DetectionScript='C:\det.ps1' }
+        $r.Success        | Should -BeFalse
+        $r.DetectionState | Should -Be 'not-installed'
+        ($r.ErrorLines -join ' ') | Should -Match 'something failed'
+    }
+
+    It 'reports Success for a clean uninstall (detection shows not-installed)' {
+        Mock Get-Module -MockWith { [pscustomobject]@{ Name='Invoke-CommandAs' } }
+        Mock Import-Module -MockWith { }
+        Mock Invoke-CommandAs -MockWith { [pscustomobject]@{ DeployExitCode=0; DeployOutput='removed'; DetectExitCode=0; DetectOutput='' } }
+        Set-Content (Join-Path $script:logdir 'App_PSAppDeployToolkit_Uninstall.log') "Uninstall complete"
+        $r = & $script:invoke @{ DeploymentType='Uninstall'; DetectionScript='C:\det.ps1' }
+        $r.Success        | Should -BeTrue
+        $r.DetectionState | Should -Be 'not-installed'
+    }
+}


### PR DESCRIPTION
Adds an opt-in, agent-driven test loop that installs/uninstalls/reinstalls a freshly built package as the SYSTEM account (mirroring the Intune Management Extension) before packaging, auto-fixing until green or a max-iteration cap.

## What
- `scripts/Invoke-PsadtSystemTest.ps1` — runs ONE deployment action (Install/Uninstall/Repair) as SYSTEM via the Invoke-CommandAs module, runs detection in the same context, reads the PSADT log, returns a structured result { ExitCode, Success, DetectionState, LogPath, LogTail, ErrorLines, Elevated }. Self-heals the module; elevation guard.
- SKILL.md: new Phase 5.5 (the loop) + Phase 8 now prefers Invoke-CommandAs over PsExec.
- README: shipped feature + requirements note + Changelog section.

## Safety
Local SYSTEM install is invasive: opt-in confirmation before first install, hard iteration cap, defined end state (default uninstalled/clean), per-iteration log audit, elevation required.

## Tests
Pester 18/18 green (5 new for the harness; all SYSTEM/network calls mocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)