### PR TITLE
Add WinGet (PSAppDeployToolkit.WinGet) support + MSI Icon table logo extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ testResults*.xml
 
 # Local planning / specs (superpowers) - NEVER commit, stays local
 docs/superpowers/
+CWindowsTempskill-diff.txt
+CWindowsTempskill-ours.md
+CWindowsTempskill-upstream.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -33,6 +33,8 @@ You guide the user through the complete lifecycle of a PSADT v4.x Intune package
 
 ## Conventions (BINDING)
 
+- **Always Windows PowerShell 5.1, never PowerShell 7:** All command invocations in this skill use `powershell` / `powershell.exe` (Windows PowerShell 5.1), **never** `pwsh` / `pwsh.exe` (PowerShell 7). Intune IME and SCCM execute packages under PS5.1; running build/test steps in PS7 can mask PS5.1 compatibility issues and produce false-green pre-flight results. This applies to all skill scripts, scaffold commands, pre-flight checks, and acid tests. The only exception is the agent's own internal tooling where PS7 is the shell — even then, any subprocess that touches PSADT must be spawned as `powershell.exe`.
+
 - **Language - split by target:**
   - **Intune dossier (`Intune-Dossier.html`, full HTML) - but the app description block for the Company Portal field is Markdown** (that field supports only Markdown, not HTML). **Language from `language.dossier`, default GERMAN with real umlauts** (ä, ö, ü, ß) - this is end-user text for the Company Portal, where umlauts are correct and desired (do NOT spell out ae/oe/ue). The dossier language is a config value, not a fixed rule.
   - **In the scripts themselves (Invoke-AppDeployToolkit.ps1, Extensions, Detection): EVERYTHING in ENGLISH** - especially all comments. Keep script strings in English too, so that no umlauts/non-ASCII end up in the PS1 (encoding cleanliness, see pre-flight). Umlauts belong ONLY in the dossier HTML, never in the script.
@@ -53,7 +55,7 @@ You guide the user through the complete lifecycle of a PSADT v4.x Intune package
 
 Before anything else happens: make sure the skill is configured and the prerequisites are in place.
 
-1. Run `pwsh scripts/Get-PsadtConfig.ps1`. If `Exists` is true and `Missing` is empty, go straight to intake.
+1. Run `powershell scripts/Get-PsadtConfig.ps1`. If `Exists` is true and `Missing` is empty, go straight to intake.
 2. If the config is missing/incomplete, run the **setup wizard** — ask only for the missing values, ALWAYS via `AskUserQuestion` (click options), recommended option first:
    - **Paths**: `paths.packageRoot`, `paths.outputRoot`, `paths.intuneWinAppUtil` (offer the current values as defaults).
    - **Languages**: `language.script` (EN), `language.dossier` (DE as default — but a config value, not fixed).
@@ -61,9 +63,9 @@ Before anything else happens: make sure the skill is configured and the prerequi
    - **Intune upload** *(planned for a future version — NOT active in this version)*: mention that it is coming; do NOT ask for tenant/client ID/secret, do NOT set `intune.uploadEnabled`. For now the finished `.intunewin` is uploaded manually in the Admin Center.
 3. Persist answers with `scripts/Set-PsadtConfig.ps1 -Updates @{ ... }` (in this version without `-Secret`).
 4. Provision prerequisites (never block the user):
-   - `pwsh scripts/Get-PsadtModule.ps1` — installs/updates PSAppDeployToolkit.
-   - `pwsh scripts/Get-IntuneWinAppUtil.ps1` — downloads/updates the content-prep tool into `tools/`.
-   - `pwsh scripts/Get-WinGetModule.ps1` — downloads/caches PSAppDeployToolkit.WinGet to `tools/`. Run at scaffold time for WinGet packages only; skip for MSI/EXE packages. Re-triggerable to update the module to the latest release.
+   - `powershell scripts/Get-PsadtModule.ps1` — installs/updates PSAppDeployToolkit.
+   - `powershell scripts/Get-IntuneWinAppUtil.ps1` — downloads/updates the content-prep tool into `tools/`.
+   - `powershell scripts/Get-WinGetModule.ps1` — downloads/caches PSAppDeployToolkit.WinGet to `tools/`. Run at scaffold time for WinGet packages only; skip for MSI/EXE packages. Re-triggerable to update the module to the latest release.
 5. Re-triggerable at any time via "psadt setup" to change individual values.
 
 ### 1. Intake (right at the start, before anything else)
@@ -90,10 +92,15 @@ Optionally follow up depending on context via a further `AskUserQuestion` call: 
 After intake, without asking back, immediately run **three parallel research streams**:
 
 **a) Check PSADT version sync AND command changes:**
+
+> **Run as a temp file, not inline:** Multi-line `powershell -Command "..."` blocks silently fail on Windows. Always write the snippet to a temp `.ps1` and invoke with `powershell -NonInteractive -ExecutionPolicy Bypass -File <path>`.
+
 ```powershell
+# Save as e.g. $env:TEMP\psadt-ver.ps1 and run with -File
 $local = (Get-Module -ListAvailable -Name PSAppDeployToolkit | Sort-Object Version -Descending | Select-Object -First 1).Version
 $rel = Invoke-RestMethod 'https://api.github.com/repos/PSAppDeployToolkit/PSAppDeployToolkit/releases/latest'
 "local=$local latest=$($rel.tag_name)"
+$rel.body -split "`n" | Select-String -Pattern 'Break|renam|deprecat|remov|new.func' | Select-Object -First 15 | ForEach-Object { $_.Line }
 ```
 If divergent: inform the user + recommend `Update-Module PSAppDeployToolkit -Force` BEFORE scaffold.
 
@@ -119,16 +126,31 @@ Show the finding to the user (which commands are new/changed/deprecated and what
 Record per deployment type: switch, expected exit codes, log path, known leftovers.
 
 **b-WinGet) Package discovery (replaces stream b when installer type = WinGet):**
-```powershell
-# Verify the package ID exists and show available versions
-Find-ADTWinGetPackage -Id '<PackageId>' | Format-List Id, Name, Version, Source
-# If the ID is uncertain, search by display name
-Find-ADTWinGetPackage -Name '<AppName>' | Select-Object Id, Name, Version
-```
-If package not found: stop and ask the user to correct the ID — do NOT scaffold with an invalid ID.
 
-Research the WinGet manifest for detection hints (ProductCode, installer type, known file paths):
+> **Module import required:** `Find-ADTWinGetPackage` comes from PSAppDeployToolkit.WinGet. Import it explicitly before calling:
+> ```powershell
+> Import-Module 'C:\Users\<user>\.claude\skills\psadt-deploy\tools\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd1' -ErrorAction SilentlyContinue
+> ```
+> (The skill's `tools/` path is in config under `paths.intuneWinAppUtil`'s parent — adjust if the skill root differs.)
+
+> **Always search by name first** when the exact ID is not already known with certainty. WinGet IDs follow `Publisher.AppName` dot-notation where each word is its own segment — `Microsoft.Sysinternals.Suite`, NOT `Microsoft.SysinternalsSuite`. Guessing the concatenated form wastes a lookup.
+
+```powershell
+# Step 1: Search by display name to discover the exact ID
+Find-ADTWinGetPackage -Name '<AppName>' | Select-Object Id, Name, Version, Source | Format-Table -AutoSize
+
+# Step 2: Confirm the chosen ID exists and show full details
+Find-ADTWinGetPackage -Id '<ConfirmedPackageId>' | Format-List Id, Name, Version, Source
+```
+
+**Fallback if WinGet/module is not available on the build machine:** look up the package ID at https://winstall.app/ (web UI over the winget-pkgs repo). This is a last resort — `Find-ADTWinGetPackage` is always preferred because it confirms the ID resolves at runtime on this machine.
+
+If package not found after both steps: stop and ask the user to correct the ID — do NOT scaffold with an invalid ID.
+
+Research the WinGet manifest for detection hints (ProductCode, installer type, known exe names, install path):
 `https://github.com/microsoft/winget-pkgs/tree/master/manifests/<first-letter>/<publisher>/<app>/<version>/`
+
+For WinGet **portable** packages: the manifest's `InstallerType: portable` means WinGet places files under `%ProgramFiles%\WinGet\Packages\<Id>_<Arch>\` and creates shims in `%ProgramFiles%\WinGet\Links\`. The exact exe names inside the Links folder come from the manifest — check the `.yaml` before coding them into shortcut lists. Always guard shortcut creation with `if (Test-Path $exePath)` so a wrong name logs a warning rather than failing the deployment.
 
 Add to stream c for WinGet packages: `"<AppName>" winget intune deployment known issues`.
 
@@ -176,7 +198,7 @@ Both must match.
 **For WinGet packages only** — provision the extension module into the package folder immediately after scaffold:
 ```powershell
 # Download module to tools/ (if not current) and copy into this package
-pwsh scripts/Get-WinGetModule.ps1 -SkillRoot '<skillRoot>' -PackagePath '<pkg>'
+powershell scripts/Get-WinGetModule.ps1 -SkillRoot '<skillRoot>' -PackagePath '<pkg>'
 # Verify
 (Import-PowerShellDataFile '<pkg>\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd1').ModuleVersion
 ```
@@ -201,11 +223,14 @@ The user places the installer in `<pkg>\Files\`. Then fill **all three hooks** i
 Mandatory before install: `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CheckDiskSpace -RequiredDiskSpace <MB>` (no-op in silent, active in interactive). Then `Show-ADTInstallationProgress` for the welcome-replacement display.
 
 **Shortcuts - ONLY Start Menu, NEVER desktop:** If the app needs a shortcut, create exclusively a
-Start Menu entry for all users (`$envCommonStartMenuPrograms`, e.g.
-`New-ADTShortcut -Path "$envCommonStartMenuPrograms\<App>\<App>.lnk" -TargetPath ...`). **No desktop icons**
-(`$envCommonDesktop` / `$envUserDesktop`) - that clutters the desktop and is unwanted in the enterprise.
-If the installer creates a desktop icon on its own: remove it again specifically in post-install
-(`Remove-Item "$envCommonDesktop\<App>.lnk"`). In uninstall, clean up the Start Menu entry as well.
+Start Menu entry for all users. **No desktop icons** (`$envCommonDesktop` / `$envUserDesktop`) — that clutters the desktop and is unwanted in the enterprise. If the installer creates a desktop icon on its own: remove it again specifically in post-install. In uninstall, clean up the Start Menu entry as well.
+
+Use `$envCommonStartMenuPrograms` **inside a deployment function** (e.g. `Install-ADTDeployment`), where it is guaranteed to be set by the PSADT session. **Never reference it at top-level script scope** (in the Variables section before `Open-ADTSession`): the session variable is `$null` there, so a path built from it is silently broken. If you need a top-level constant for the path, use the native Windows equivalent:
+```powershell
+# Safe at top level - does not depend on PSADT session state
+$startMenuDir = "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\<App>"
+```
+The same restriction applies to all `$env*` PSADT session variables: `$envCommonDesktop`, `$envUserDesktop`, `$envProfilesDirectory`, `$envWinDir`, etc.
 
 **4b. `Uninstall-ADTDeployment`** — values from intake question 7 (what goes, what stays):
 
@@ -285,7 +310,7 @@ $moduleManifest = '<pkg>\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd
 if (Test-Path $moduleManifest) {
     "WinGet module: $((Import-PowerShellDataFile $moduleManifest).ModuleVersion) — OK"
 } else {
-    "WinGet module MISSING — run: pwsh scripts/Get-WinGetModule.ps1 -PackagePath '<pkg>'"
+    "WinGet module MISSING — run: powershell scripts/Get-WinGetModule.ps1 -PackagePath '<pkg>'"
 }
 ```
 
@@ -298,7 +323,9 @@ $text = $text -replace [char]0x2014, '-' -replace [char]0x2013, '-' -replace [ch
 [System.IO.File]::WriteAllText($s, $text, [System.Text.UTF8Encoding]::new($true))
 ```
 
-If check 3 is too dangerous because a real install would start: use the test stub from guide appendix C (replace the Install-ADTDeployment call with an `exit 77` stub, launcher test, expects exit 77).
+**For WinGet packages, Check 3 WILL trigger a real installation — always use the test stub instead of skipping.** Skipping silently leaves scope bugs and path errors undetected. The stub replaces the deployment functions with a controlled exit and verifies the launcher finds and loads the script correctly without installing anything. See appendix C for the full stub pattern. After the stub passes, defer the live install/uninstall/repair verification to Phase 8 on a DEV VM.
+
+If check 3 is too dangerous for other reasons (real installer would run, licence key consumed, etc.): same rule — use the test stub from guide appendix C (replace the Install-ADTDeployment call with an `exit 77` stub, launcher test, expects exit 77).
 
 Additionally scan:
 ```powershell
@@ -334,7 +361,7 @@ nothing — YOU (the agent) drive the loop and apply fixes between runs.
 - Keep each iteration's PSADT log in the output folder for an audit trail.
 
 **Loop (max `test.maxIterations`):**
-1. **Install:** `pwsh scripts/Invoke-PsadtSystemTest.ps1 -PackagePath <pkg> -DeploymentType Install -DetectionScript <detect>` (elevated). If not `Success`: read `LogTail`/`ErrorLines`, map to a root cause via the Troubleshooting quick-reference + guide Appendix A, fix `Install-ADTDeployment` (or Extensions), re-run.
+1. **Install:** `powershell scripts/Invoke-PsadtSystemTest.ps1 -PackagePath <pkg> -DeploymentType Install -DetectionScript <detect>` (elevated). If not `Success`: read `LogTail`/`ErrorLines`, map to a root cause via the Troubleshooting quick-reference + guide Appendix A, fix `Install-ADTDeployment` (or Extensions), re-run.
 2. **Uninstall:** run with `-DeploymentType Uninstall`. Verify `DetectionState = not-installed` AND the leftover checks (services, scheduled tasks, app registry key, install dir, firewall rules; neighbour products of the same vendor still present). On failure: fix `Uninstall-ADTDeployment`, re-run.
 3. **Reinstall:** run `Install` again; verify installed. On failure: fix, re-run.
 4. **Converged** (all three green) → leave the machine per `test.endState`, then proceed to Packaging (Phase 6) with the validated scripts.
@@ -393,7 +420,10 @@ The dossier language follows `language.dossier` (default German), and its umlaut
 **Note: direct Graph upload is planned for a future skill version.** For now the user uploads the generated `.intunewin` manually in the Intune Admin Center.
 
 **Obtain the app logo automatically (mandatory):** Search for and download a suitable logo of the app - **PNG, transparent background, high resolution** (guideline >= 512px, more is better; square is best for the Company Portal tile). Place it under `<pkg>\Assets\<App>-Logo.png` AND a copy into `Output\<App>\`. Reference the filename in the logo row of the dossier.
-- **Choose a license-clear source:** first the official vendor/project source (e.g. `apache.org/logos/res/<project>/` for Apache projects), otherwise **Wikimedia Commons** (stable URLs, SVG is rendered server-side as a transparent PNG):
+- **Choose a license-clear source in this priority order:**
+  1. **Microsoft products first:** try `https://learn.microsoft.com/en-us/<product>/media/index/<product>.png` (official Microsoft Learn assets, transparent PNG, direct download). Replace `<product>` with the lowercase product identifier (e.g. `sysinternals`, `powershell`, `sqlserver`).
+  2. **Other vendors:** official vendor/project source (e.g. `apache.org/logos/res/<project>/` for Apache projects).
+  3. **Fallback:** Wikimedia Commons (stable URLs, SVG rendered server-side as a transparent PNG):
   ```powershell
   # Wikimedia: SVG -> transparent PNG at the desired width (here 1024)
   $api = "https://commons.wikimedia.org/w/api.php?action=query&titles=$([uri]::EscapeDataString('File:<Logo>.svg'))&prop=imageinfo&iiprop=url&iiurlwidth=1024&format=json"
@@ -516,8 +546,9 @@ Check logs in this order:
 ## Anti-patterns (never do)
 
 - v3 cmdlet names (`Execute-Process`, `Write-Log`, `Show-InstallationWelcome`, ...)
-- Em-dash/smart quote in double-quoted strings
+- Em-dash/smart quote **anywhere in the script file** — this means in comments too, not just in double-quoted strings. All generated script text must be 7-bit ASCII only. Use `-` (hyphen) never `—` (U+2014) or `–` (U+2013). This is the single most common encoding failure and always requires at least two extra pre-flight runs to find and fix.
 - Saving UTF-8 without BOM when non-ASCII is present
+- Referencing PSADT session variables (`$envCommonStartMenuPrograms`, `$envCommonDesktop`, `$envProfilesDirectory`, …) at top-level script scope in the Variables section — they are `$null` there because `Open-ADTSession` has not run yet. Use `$env:ProgramData`, `$env:SystemRoot`, etc. at the top level, or define the derived paths inside the deployment functions.
 - Top-level code outside try/catch
 - `-o` inside `-c` for IntuneWinAppUtil
 - Not mapping return codes 60001/60008 as Failed

--- a/SKILL.md
+++ b/SKILL.md
@@ -133,7 +133,7 @@ Record per deployment type: switch, expected exit codes, log path, known leftove
 > ```
 > (The skill's `tools/` path is in config under `paths.intuneWinAppUtil`'s parent — adjust if the skill root differs.)
 
-> **Always search by name first** when the exact ID is not already known with certainty. WinGet IDs follow `Publisher.AppName` dot-notation where each word is its own segment — `Microsoft.Sysinternals.Suite`, NOT `Microsoft.SysinternalsSuite`. Guessing the concatenated form wastes a lookup.
+> **Always search by name first** when the exact ID is not already known with certainty. WinGet IDs follow `Publisher.AppName` dot-notation where each word is its own segment — e.g. `Valve.Steam` or `Microsoft.PowerShell.Preview`, NOT `MicrosoftPowerShellPreview`. Guessing the concatenated form wastes a lookup.
 
 ```powershell
 # Step 1: Search by display name to discover the exact ID
@@ -421,7 +421,7 @@ The dossier language follows `language.dossier` (default German), and its umlaut
 
 **Obtain the app logo automatically (mandatory):** Search for and download a suitable logo of the app - **PNG, transparent background, high resolution** (guideline >= 512px, more is better; square is best for the Company Portal tile). Place it under `<pkg>\Assets\<App>-Logo.png` AND a copy into `Output\<App>\`. Reference the filename in the logo row of the dossier.
 - **Choose a license-clear source in this priority order:**
-  1. **Microsoft products first:** try `https://learn.microsoft.com/en-us/<product>/media/index/<product>.png` (official Microsoft Learn assets, transparent PNG, direct download). Replace `<product>` with the lowercase product identifier (e.g. `sysinternals`, `powershell`, `sqlserver`).
+  1. **Microsoft products first:** try `https://learn.microsoft.com/en-us/<product>/media/index/<product>.png` (official Microsoft Learn assets, transparent PNG, direct download). Replace `<product>` with the lowercase product identifier (e.g. `powershell`, `sqlserver`, `azure`).
   2. **Other vendors:** official vendor/project source (e.g. `apache.org/logos/res/<project>/` for Apache projects).
   3. **Fallback:** Wikimedia Commons (stable URLs, SVG rendered server-side as a transparent PNG):
   ```powershell

--- a/SKILL.md
+++ b/SKILL.md
@@ -431,6 +431,56 @@ The dossier language follows `language.dossier` (default German), and its umlaut
   Invoke-WebRequest $thumb -OutFile '<pkg>\Assets\<App>-Logo.png' -Headers @{'User-Agent'='PSADT-pkg/1.0'}
   ```
   Avoid third-party PNG portals (stickpng, toppng, nicepng ...) - hotlink protection/ads/questionable quality.
+  4. **MSI Icon table fallback (when web download fails):** MSI installers embed .ico files in an `Icon` table. Export via COM, read the raw ICO binary, and extract the largest frame directly as bytes (System.Drawing.Icon cannot decode PNG-compressed 256x256 frames embedded in .ico on .NET Framework 4.x - extract raw bytes instead):
+  ```powershell
+  Add-Type -AssemblyName System.Drawing
+  Add-Type -TypeDefinition @'
+  using System; using System.Drawing; using System.Drawing.Imaging; using System.Runtime.InteropServices;
+  public class IcoDibReader {
+      public static Bitmap FromDib32(byte[] dib, int width, int height) {
+          int pixelDataSize = width * height * 4;
+          var pixels = new byte[pixelDataSize];
+          Array.Copy(dib, 40, pixels, 0, pixelDataSize);  // skip 40-byte BITMAPINFOHEADER
+          var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+          var bd = bmp.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
+          int rb = width * 4;
+          for (int r = 0; r < height; r++) Marshal.Copy(pixels, (height-1-r)*rb, IntPtr.Add(bd.Scan0, r*bd.Stride), rb);
+          bmp.UnlockBits(bd); return bmp;
+      }
+  }
+  '@ -ReferencedAssemblies 'System.Drawing'
+
+  $tmpDir = "$env:TEMP\MsiIconExport"; New-Item $tmpDir -ItemType Directory -Force | Out-Null
+  $type = [System.Type]::GetTypeFromProgID('WindowsInstaller.Installer')
+  $db   = [System.Activator]::CreateInstance($type).OpenDatabase('<path-to.msi>', 0)
+  $db.Export('Icon', $tmpDir, 'Icon.idt')
+
+  # The Icon table binary streams export as <IconName>.ico.ibd in a subfolder named 'Icon'
+  $icoPath = Get-ChildItem "$tmpDir\Icon" -Filter '*.ibd' | Sort-Object Length -Descending | Select-Object -ExpandProperty FullName -First 1
+  $allBytes = [System.IO.File]::ReadAllBytes($icoPath)
+
+  # Find the largest frame in the ICO
+  $count = [BitConverter]::ToUInt16($allBytes, 4)
+  $bestW = 0; $bestOff = 0; $bestSize = 0
+  for ($i = 0; $i -lt $count; $i++) {
+      $base = 6 + $i * 16
+      $w    = [int]$allBytes[$base]; if ($w -eq 0) { $w = 256 }
+      if ($w -gt $bestW) { $bestW = $w; $bestOff = [BitConverter]::ToUInt32($allBytes, $base+12); $bestSize = [BitConverter]::ToUInt32($allBytes, $base+8) }
+  }
+  $frame = New-Object byte[] $bestSize; [Array]::Copy($allBytes, $bestOff, $frame, 0, $bestSize)
+
+  # Check if PNG-compressed (signature 0x89 0x50 0x4E 0x47)
+  if ($frame[0] -eq 0x89 -and $frame[1] -eq 0x50) {
+      [System.IO.File]::WriteAllBytes('<output>.png', $frame)  # PNG frame: write directly
+  } else {
+      # BMP DIB frame: decode with row-flip (bottom-up) and strip AND mask
+      $biH = [Math]::Abs([BitConverter]::ToInt32($frame, 8)) / 2
+      $bmp = [IcoDibReader]::FromDib32($frame, $bestW, [int]$biH)
+      $bmp.Save('<output>.png', [System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
+  }
+  Remove-Item $tmpDir -Recurse -Force
+  ```
+  Note: `System.Drawing.Icon($path, 256, 256)` silently falls back to 48x48 when the 256x256 frame is PNG-compressed in the .ico - always parse the ICO binary directly for best results.
 - **Verify** (transparency + resolution) and show the user that it is the right logo:
   ```powershell
   Add-Type -AssemblyName System.Drawing

--- a/SKILL.md
+++ b/SKILL.md
@@ -63,6 +63,7 @@ Before anything else happens: make sure the skill is configured and the prerequi
 4. Provision prerequisites (never block the user):
    - `pwsh scripts/Get-PsadtModule.ps1` — installs/updates PSAppDeployToolkit.
    - `pwsh scripts/Get-IntuneWinAppUtil.ps1` — downloads/updates the content-prep tool into `tools/`.
+   - `pwsh scripts/Get-WinGetModule.ps1` — downloads/caches PSAppDeployToolkit.WinGet to `tools/`. Run at scaffold time for WinGet packages only; skip for MSI/EXE packages. Re-triggerable to update the module to the latest release.
 5. Re-triggerable at any time via "psadt setup" to change individual values.
 
 ### 1. Intake (right at the start, before anything else)
@@ -73,8 +74,9 @@ Ask the **8 kill questions exclusively via the `AskUserQuestion` tool** (clickab
 
 The 8 substantive questions that must be covered (spread across the two calls):
 1. **App + exact version** - options: detected/latest version (recommended), known previous version(s), from context.
-2. **Installer type** - options: MSI, EXE wrapper, MSIX, InstallShield, Squirrel/ZIP/portable, other.
-3. **Installer source** - options: available locally (path follows), download + bundle into the package (recommended), download at runtime.
+2. **Installer type** - options: MSI, EXE wrapper, MSIX, InstallShield, Squirrel/ZIP/portable, WinGet package, other.
+   - If **WinGet selected**: inject a follow-up `AskUserQuestion` before Q3 covering: Package ID (e.g. `Valve.Steam`, `Microsoft.PowerShell` — user provides or Phase 2b confirms), scope (`Machine` recommended — required for Intune SYSTEM context), version (`Latest` recommended vs pinned). Then **skip Q3** — WinGet packages have no local installer to source.
+3. **Installer source** - options: available locally (path follows), download + bundle into the package (recommended), download at runtime. *(Skip for WinGet — Package ID is the source; see Q2 above.)*
 4. **Target audience** - options: Required on devices, Available in Company Portal, both; pull in AAD groups as free text if needed.
 5. **Special config** - options: none (recommended default if nothing is known), registry keys, XML/JSON/settings file, license key, service account, branding (multiSelect: true makes sense).
 6. **Reboot behavior** - options: never (recommended), recommended (3010), forced (1641).
@@ -115,6 +117,20 @@ Show the finding to the user (which commands are new/changed/deprecated and what
 - Official vendor docs first, then silentinstallhq.com, then community (Reddit r/Intune, PSADT Discourse)
 
 Record per deployment type: switch, expected exit codes, log path, known leftovers.
+
+**b-WinGet) Package discovery (replaces stream b when installer type = WinGet):**
+```powershell
+# Verify the package ID exists and show available versions
+Find-ADTWinGetPackage -Id '<PackageId>' | Format-List Id, Name, Version, Source
+# If the ID is uncertain, search by display name
+Find-ADTWinGetPackage -Name '<AppName>' | Select-Object Id, Name, Version
+```
+If package not found: stop and ask the user to correct the ID — do NOT scaffold with an invalid ID.
+
+Research the WinGet manifest for detection hints (ProductCode, installer type, known file paths):
+`https://github.com/microsoft/winget-pkgs/tree/master/manifests/<first-letter>/<publisher>/<app>/<version>/`
+
+Add to stream c for WinGet packages: `"<AppName>" winget intune deployment known issues`.
 
 **c) Known Intune pitfalls:**
 - Query: `"<AppName>" intune win32 known issues`
@@ -157,6 +173,15 @@ Select-String "$pkg\Invoke-AppDeployToolkit.ps1" -Pattern 'DeployAppScriptVersio
 ```
 Both must match.
 
+**For WinGet packages only** — provision the extension module into the package folder immediately after scaffold:
+```powershell
+# Download module to tools/ (if not current) and copy into this package
+pwsh scripts/Get-WinGetModule.ps1 -SkillRoot '<skillRoot>' -PackagePath '<pkg>'
+# Verify
+(Import-PowerShellDataFile '<pkg>\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd1').ModuleVersion
+```
+PSADT's extension auto-loader discovers `PSAppDeployToolkit.WinGet\` by folder-name match and imports it automatically — no `Import-Module` in the deployment script. The `Files\` folder remains empty for WinGet packages (nothing to bundle). Set `AppVersion = 'Latest'` in `$adtSession` (or `'<pinned>'` if a fixed version was requested); read `AppArch` from the WinGet manifest installer type.
+
 ### 4. Script customizing — all three deployment types
 
 The user places the installer in `<pkg>\Files\`. Then fill **all three hooks** in `Invoke-AppDeployToolkit.ps1`: `Install-ADTDeployment`, `Uninstall-ADTDeployment`, `Repair-ADTDeployment`. Even if only install is needed today: later user uninstalls via Company Portal only work with a filled uninstall block.
@@ -167,6 +192,11 @@ The user places the installer in `<pkg>\Files\`. Then fill **all three hooks** i
 - EXE wrapper: `Start-ADTProcess -FilePath "$($adtSession.DirFiles)\<setup>.exe" -ArgumentList '<researched silent switches>' -SuccessExitCodes @(0, 3010, 1641)`
 - InstallShield with `setup.exe /s /f1"<response>.iss"`: response file in `SupportFiles\`
 - Squirrel (`<app>-<ver>-full.nupkg`-based .exe): often `/silent /quiet`
+- WinGet:
+  ```powershell
+  Repair-ADTWinGetPackageManager                                        # self-heal WinGet before every operation
+  Install-ADTWinGetPackage -Id '<WinGetId>' -Scope Machine -Mode Silent # add -Version '<ver>' if pinned
+  ```
 
 Mandatory before install: `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CheckDiskSpace -RequiredDiskSpace <MB>` (no-op in silent, active in interactive). Then `Show-ADTInstallationProgress` for the welcome-replacement display.
 
@@ -183,6 +213,7 @@ If the installer creates a desktop icon on its own: remove it again specifically
 - MSI via DisplayName match (when ProductCode varies): `Remove-ADTApplication -Name '<AppName>' -NameMatch Exact` (not `Contains` - that accidentally removes neighboring products with a name prefix)
 - EXE with its own uninstaller: `Start-ADTProcess -FilePath '<uninstallstring-from-registry>' -ArgumentList '<silent uninstall switches>'`
 - Squirrel: `Start-ADTProcess -FilePath "$env:LocalAppData\<app>\update.exe" -ArgumentList '--uninstall -s'`
+- WinGet: `Uninstall-ADTWinGetPackage -Id '<WinGetId>' -Mode Silent`
 
 Post-uninstall cleanup (based on intake question 7):
 - `Show-ADTInstallationWelcome -CloseProcesses $adtSession.AppProcessesToClose -CloseProcessesCountdown 60` (not `-Silent` - uninstalls should be allowed to kill processes)
@@ -201,6 +232,17 @@ Counter-example to warn about: NEVER do `Remove-Item 'HKLM:\SOFTWARE\<vendor>' -
 - MSI: `Start-ADTMsiProcess -Action Repair -FilePath '{<ProductCode>}' -ArgumentList '/fa /qn'` (`/fa` = all files reinstalled, shortcuts + registry are set again)
 - EXE wrapper without a dedicated repair mode: uninstall followed by install in the same hook; preserve user config if possible (backup-restore logic if needed)
 - Config-only repair: stop the service, copy the config files back from `SupportFiles\`, start the service - without reinstalling the app (faster, less invasive)
+- WinGet:
+  ```powershell
+  try {
+      Repair-ADTWinGetPackage -Id '<WinGetId>'
+  } catch {
+      Write-ADTLogEntry -Message "WinGet repair not supported; performing uninstall + reinstall."
+      Uninstall-ADTWinGetPackage -Id '<WinGetId>' -Mode Silent
+      Repair-ADTWinGetPackageManager
+      Install-ADTWinGetPackage -Id '<WinGetId>' -Scope Machine -Mode Silent
+  }
+  ```
 
 **Custom helpers** ALWAYS in `<pkg>\PSAppDeployToolkit.Extensions\PSAppDeployToolkit.Extensions.psm1`, never in the main script.
 
@@ -236,6 +278,17 @@ foreach ($dt in 'Install','Uninstall','Repair') {
 
 If one of the three types turns red: that is NOT ok even if install is green. Otherwise the Company Portal user gets 0x80070001 when clicking uninstall.
 
+For WinGet packages, add:
+```powershell
+# Check 4: WinGet extension module present in package
+$moduleManifest = '<pkg>\PSAppDeployToolkit.WinGet\PSAppDeployToolkit.WinGet.psd1'
+if (Test-Path $moduleManifest) {
+    "WinGet module: $((Import-PowerShellDataFile $moduleManifest).ModuleVersion) — OK"
+} else {
+    "WinGet module MISSING — run: pwsh scripts/Get-WinGetModule.ps1 -PackagePath '<pkg>'"
+}
+```
+
 On an encoding bug (check 1 red or check 3 parse errors): replace em-dashes / smart quotes + UTF-8 BOM:
 ```powershell
 $text = [System.IO.File]::ReadAllText($s, [System.Text.Encoding]::UTF8)
@@ -249,8 +302,8 @@ If check 3 is too dangerous because a real install would start: use the test stu
 
 Additionally scan:
 ```powershell
-# v3 leftovers
-$v3 = 'Execute-Process','Execute-MSI','Write-Log','Show-InstallationWelcome','Show-InstallationProgress','Show-InstallationPrompt','Get-InstalledApplication','Remove-MSIApplications','Refresh-Desktop','Update-GroupPolicy','Block-AppExecution'
+# v3 leftovers (+ WinGet wrong-prefix guard)
+$v3 = 'Execute-Process','Execute-MSI','Write-Log','Show-InstallationWelcome','Show-InstallationProgress','Show-InstallationPrompt','Get-InstalledApplication','Remove-MSIApplications','Refresh-Desktop','Update-GroupPolicy','Block-AppExecution','Assert-WinGetPackageManager','Get-WinGetPackage','Install-WinGetPackage','Uninstall-WinGetPackage','Repair-WinGetPackage','Repair-WinGetPackageManager'
 $t = [System.IO.File]::ReadAllText($s)
 foreach ($fn in $v3) { $m = [regex]::Matches($t, "\b$fn\b"); if ($m.Count) { "V3_FOUND: $fn ($($m.Count)x)" } }
 
@@ -384,6 +437,26 @@ More info: [Vendor page](https://...)
 
 Mandatory return codes that must always be included: `0 Success, 1707 Success, 3010 Soft reboot, 1641 Hard reboot, 1618 Retry, 60001 Failed, 60008 Failed` + installer-specific codes from the research.
 
+**For WinGet packages — additional dossier requirements:**
+- Requirements table: add `Windows Package Manager (WinGet) >= 1.7.10582` — note that `Repair-ADTWinGetPackageManager` in the install hook self-heals this automatically.
+- Detection note: The PSAppDeployToolkit.WinGet module is bundled inside the `.intunewin` and extracted at install time only — it is **NOT** present on the device during Intune's detection phase. Detection must use registry or file checks only. Never use `Get-ADTWinGetPackage` in a detection script. Recommended template for WinGet-installed apps:
+  ```powershell
+  # Detect-<AppName>.ps1 — registry-based, works regardless of ProductCode stability
+  $regBases = @(
+      'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+      'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+  )
+  foreach ($base in $regBases) {
+      $match = Get-ChildItem $base -ErrorAction SilentlyContinue |
+          Get-ItemProperty |
+          Where-Object { $_.DisplayName -like '<AppName>*' } |
+          Select-Object -First 1
+      if ($match) { Write-Output "Detected: $($match.DisplayName) $($match.DisplayVersion)"; exit 0 }
+  }
+  exit 1
+  ```
+  For apps whose WinGet manifest includes a stable `ProductCode`, use the direct GUID key (`HKLM:\...\Uninstall\{<ProductCode>}`) — faster and more reliable than a DisplayName scan.
+
 ### 8. Test sequence (BEFORE production rollout) — all three deployment types
 
 On a DEV VM in this order. After each successful install comes the uninstall test on **the same VM** (not a new VM) - so that uninstall actually has something to clean up.
@@ -456,6 +529,11 @@ Check logs in this order:
 - Triggering fallback delete actions on the first negative async response (services need 30-60s after msiexec, build a retry loop)
 - Creating desktop icons (or leaving ones created by the installer) - Start Menu entries only, keep the desktop clean
 - Recognizing a newer PSADT version only by its number and adopting it blindly - always check the release notes/changelog for changed/deprecated commands
+- Using `Get-ADTWinGetPackage` in a detection script — the WinGet module lives inside `.intunewin` and is not present on the device at detection time; use registry or file detection only
+- `-Scope User` in WinGet Intune deployments — Intune SYSTEM context has no mounted user hive; always use `-Scope Machine`
+- Skipping `Repair-ADTWinGetPackageManager` before `Install-ADTWinGetPackage` — WinGet may be absent or outdated on managed devices; always self-heal first
+- Mixing `Install-ADTWinGetPackage` with `Start-ADTProcess`/`Start-ADTMsiProcess` in the same deployment type hook — use one installation paradigm per hook
+- Using bare WinGet cmdlet names without the `ADT` prefix (`Install-WinGetPackage`, `Repair-WinGetPackageManager`, `Assert-WinGetPackageManager`, …) — those are the non-PSADT cmdlets and bypass logging, error handling, and the PSADT session; always use the `*-ADTWinGet*` versions from the extension module
 
 ## Reference lookup
 

--- a/references/app-registration.md
+++ b/references/app-registration.md
@@ -5,8 +5,27 @@ Microsoft Graph **application** permission `DeviceManagementApps.ReadWrite.All`.
 
 **Preferred path:** run `pwsh scripts/New-PsadtEntraApp.ps1` once. It signs you in interactively via **WAM**
 (the Windows Web Account Manager broker; device-code fallback), creates the app, grants + admin-consents the
-permission, creates a client secret, and stores everything automatically. Use the manual steps below only
-when you cannot run that script (locked-down host, policy, etc.).
+permission, and stores the credential automatically. Use the manual steps below only when you cannot run
+that script (locked-down host, policy, etc.).
+
+**Certificate vs client secret:** certificate auth is preferred for personal use — no DPAPI portability
+constraint, no secret to rotate on a tight schedule, and the private key never leaves your machine.
+If you already have a cert in `Cert:\CurrentUser\My`, pass `-UseCertificate -CertThumbprint <thumb>`:
+
+```powershell
+# Create a self-signed cert (one time, 10-year expiry)
+$c = New-SelfSignedCertificate -Subject 'CN=<you> - Intune Automation' `
+     -CertStoreLocation 'Cert:\CurrentUser\My' -KeyAlgorithm RSA -KeyLength 4096 `
+     -KeyUsage DigitalSignature -NotAfter (Get-Date).AddYears(10) -HashAlgorithm SHA256
+$c.Thumbprint   # note this value
+
+# Bootstrap the Entra app with the cert (no secret created)
+pwsh scripts/New-PsadtEntraApp.ps1 -UseCertificate -CertThumbprint $c.Thumbprint
+```
+
+The script uploads the cert's public key to the app registration, stores the thumbprint in `config.json`
+(gitignored), and configures `Get-GraphToken.ps1` to sign JWT client assertions with the private key at
+upload time. No secret file is created; `secret.dpapi` is not needed.
 
 You must sign in as **Global Administrator** or **Privileged Role Administrator** — granting admin consent
 for an application permission requires it. Application Administrator alone cannot complete the consent step.
@@ -25,16 +44,39 @@ for an application permission requires it. Application Administrator alone canno
 3. Click **Grant admin consent for &lt;tenant&gt;** and confirm. The permission row must show
    **Granted for &lt;tenant&gt;** (green check). Without this the upload's read-only probe returns `403`.
 
-## 3. Create a client secret
+## 3. Create a credential (choose one)
+
+### Option A — Certificate (preferred)
+
+1. Export the public key of your cert as a `.cer` file:
+
+   ```powershell
+   Export-Certificate -Cert "Cert:\CurrentUser\My\<Thumbprint>" -FilePath "$env:TEMP\intune-auth.cer"
+   ```
+
+2. App → **Certificates & secrets → Certificates → Upload certificate** → select `intune-auth.cer`. **Add**.
+3. The thumbprint shown in the portal must match your cert's thumbprint. No value to copy.
+
+### Option B — Client secret
 
 1. App → **Certificates & secrets → Client secrets → New client secret**.
 2. Description `PSADT upload secret`, pick an expiry (e.g. 12 months). **Add**.
 3. Copy the secret **Value** immediately (shown once). Do **not** paste it into chat or any file.
 
-## 4. Feed it into the skill config (secret DPAPI-encrypted)
+## 4. Feed it into the skill config
 
-Store tenant/client in `config.json` and the secret DPAPI-encrypted (`CurrentUser`) in `secret.dpapi` —
-the secret is never written to `config.json` or any log, and is decrypted only in-memory at upload time:
+**Option A — Certificate:** store only the thumbprint (not sensitive):
+
+```powershell
+& scripts/Set-PsadtConfig.ps1 -Updates @{
+    'intune.tenantId'      = '<tenant-guid>'
+    'intune.clientId'      = '<client-guid>'
+    'intune.uploadEnabled' = $true
+    'intune.certThumbprint' = '<thumbprint>'
+}
+```
+
+**Option B — Client secret:** store tenant/client in `config.json` and DPAPI-encrypt the secret to `secret.dpapi` — the plaintext is never written to any file and is zeroed from memory after each token request:
 
 ```powershell
 $secret = Read-Host -AsSecureString 'Paste the client secret value'   # typed in the terminal, never in chat

--- a/scripts/Get-GraphToken.ps1
+++ b/scripts/Get-GraphToken.ps1
@@ -3,12 +3,12 @@
     Acquires an app-only (client-credentials) Microsoft Graph token for the configured tenant/client.
 
 .DESCRIPTION
-    Reads intune.tenantId / intune.clientId from config.json and decrypts the DPAPI-stored client secret
-    (intune.secretRef, default secret.dpapi) IN-MEMORY ONLY - the plaintext is never written back, never
-    logged, and is zeroed from unmanaged memory immediately after the token request. Returns
+    Reads intune.tenantId / intune.clientId from config.json and authenticates using whichever credential
+    is configured: if intune.certThumbprint is present the cert in Cert:\CurrentUser\My is used to sign a
+    JWT client assertion (RFC 7523); otherwise the DPAPI-stored client secret (intune.secretRef, default
+    secret.dpapi) is decrypted IN-MEMORY ONLY - the plaintext is never written back, never logged, and is
+    zeroed from unmanaged memory immediately after the token request. Returns
     { Token, ExpiresOn, TenantId, ClientId }.
-
-    Shaped so a certificate thumbprint can be added later without changing call sites (secret-only for now).
 
 .PARAMETER SkillRoot
     Skill root (folder with config.json). Defaults to the parent of this script.
@@ -25,27 +25,69 @@ $cfg = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1') -SkillRoot $SkillRoot)
 if (-not $cfg.intune) { throw "config.json has no 'intune' block - run New-PsadtEntraApp.ps1 first." }
 $tenantId = $cfg.intune.tenantId
 $clientId = $cfg.intune.clientId
-$secretRef = if ($cfg.intune.secretRef) { $cfg.intune.secretRef } else { 'secret.dpapi' }
 if ([string]::IsNullOrWhiteSpace($tenantId) -or [string]::IsNullOrWhiteSpace($clientId)) {
     throw "intune.tenantId / intune.clientId missing in config.json."
 }
-$secretPath = Join-Path $SkillRoot $secretRef
-if (-not (Test-Path $secretPath)) { throw "Encrypted secret not found: $secretPath (run New-PsadtEntraApp.ps1)." }
 
-# DPAPI -> SecureString -> plaintext, in-memory only.
-$secure = ConvertTo-SecureString (Get-Content $secretPath -Raw)
-$bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
-try {
-    $plain = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+$resp = $null
+
+if (-not [string]::IsNullOrWhiteSpace([string]$cfg.intune.certThumbprint)) {
+    # --- Certificate path (RFC 7523 signed JWT client assertion) ---
+    $thumbprint = [string]$cfg.intune.certThumbprint
+    $cert = Get-Item "Cert:\CurrentUser\My\$thumbprint" -ErrorAction SilentlyContinue
+    if (-not $cert) { throw "Certificate Cert:\CurrentUser\My\$thumbprint not found. Re-run New-PsadtEntraApp.ps1 or restore the cert." }
+
+    $now = [DateTimeOffset]::UtcNow
+    $thumbBytes = [byte[]]::new(20)
+    for ($i = 0; $i -lt 40; $i += 2) { $thumbBytes[$i / 2] = [Convert]::ToByte($thumbprint.Substring($i, 2), 16) }
+
+    function ConvertTo-B64Url([string]$json) {
+        [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json)).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+    }
+    $x5t = [Convert]::ToBase64String($thumbBytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+    $hdr = ConvertTo-B64Url (([ordered]@{ alg = 'RS256'; typ = 'JWT'; x5t = $x5t } | ConvertTo-Json -Compress))
+    $pay = ConvertTo-B64Url (([ordered]@{
+        aud = "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token"
+        iss = $clientId; sub = $clientId
+        jti = [guid]::NewGuid().ToString()
+        nbf = [Int64]$now.ToUnixTimeSeconds()
+        iat = [Int64]$now.ToUnixTimeSeconds()
+        exp = [Int64]$now.AddMinutes(5).ToUnixTimeSeconds()
+    } | ConvertTo-Json -Compress))
+    $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
+    $sigBytes = $rsa.SignData([Text.Encoding]::UTF8.GetBytes("$hdr.$pay"),
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+        [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    $assertion = "$hdr.$pay.$([Convert]::ToBase64String($sigBytes).TrimEnd('=').Replace('+','-').Replace('/','_'))"
+
     $resp = Invoke-RestMethod -Method Post -Uri "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" -Body @{
-        client_id     = $clientId
-        scope         = 'https://graph.microsoft.com/.default'
-        grant_type    = 'client_credentials'
-        client_secret = $plain
+        client_id             = $clientId
+        scope                 = 'https://graph.microsoft.com/.default'
+        grant_type            = 'client_credentials'
+        client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+        client_assertion      = $assertion
     } -ErrorAction Stop
-} finally {
-    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-    $plain = $null
+
+} else {
+    # --- DPAPI client secret path ---
+    $secretRef = if ($cfg.intune.secretRef) { $cfg.intune.secretRef } else { 'secret.dpapi' }
+    $secretPath = Join-Path $SkillRoot $secretRef
+    if (-not (Test-Path $secretPath)) { throw "Encrypted secret not found: $secretPath (run New-PsadtEntraApp.ps1)." }
+
+    $secure = ConvertTo-SecureString (Get-Content $secretPath -Raw)
+    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+    try {
+        $plain = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+        $resp = Invoke-RestMethod -Method Post -Uri "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" -Body @{
+            client_id     = $clientId
+            scope         = 'https://graph.microsoft.com/.default'
+            grant_type    = 'client_credentials'
+            client_secret = $plain
+        } -ErrorAction Stop
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        $plain = $null
+    }
 }
 
 [pscustomobject]@{

--- a/scripts/Get-PsadtConfig.ps1
+++ b/scripts/Get-PsadtConfig.ps1
@@ -32,7 +32,13 @@ if ($cfg.intune -and $cfg.intune.uploadEnabled) {
     foreach ($f in 'tenantId','clientId') {
         if ([string]::IsNullOrWhiteSpace([string]$cfg.intune.$f)) { $missing.Add("intune.$f") }
     }
-    $ref = if ($cfg.intune.secretRef) { $cfg.intune.secretRef } else { 'secret.dpapi' }
-    if (-not (Test-Path (Join-Path $SkillRoot $ref))) { $missing.Add('intune.secret') }
+    if (-not [string]::IsNullOrWhiteSpace([string]$cfg.intune.certThumbprint)) {
+        if (-not (Test-Path "Cert:\CurrentUser\My\$($cfg.intune.certThumbprint)")) {
+            $missing.Add("intune.certThumbprint (cert not found in Cert:\CurrentUser\My)")
+        }
+    } else {
+        $ref = if ($cfg.intune.secretRef) { $cfg.intune.secretRef } else { 'secret.dpapi' }
+        if (-not (Test-Path (Join-Path $SkillRoot $ref))) { $missing.Add('intune.secret') }
+    }
 }
 [pscustomobject]@{ Exists = $true; Config = $cfg; Missing = $missing.ToArray(); Path = $configPath }

--- a/scripts/Get-WinGetModule.ps1
+++ b/scripts/Get-WinGetModule.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS  Ensures tools/PSAppDeployToolkit.WinGet is present and current vs the GitHub release.
+.PARAMETER PackagePath  Optional. Copies the module into <PackagePath>\PSAppDeployToolkit.WinGet\ after download.
+.OUTPUTS   PSCustomObject: Action(Downloaded|Updated|AlreadyCurrent|UpdateFailed), Version, Path
+#>
+[CmdletBinding()]
+param(
+    [string]$SkillRoot   = (Split-Path $PSScriptRoot -Parent),
+    [string]$PackagePath
+)
+$ErrorActionPreference = 'Stop'
+$repo         = 'mjr4077au/PSAppDeployToolkit.WinGet'
+$assetName    = 'PSAppDeployToolkit.WinGet.zip'
+$fallbackTag  = 'v1.0.5'
+$fallbackUrl  = "https://github.com/$repo/releases/download/$fallbackTag/$assetName"
+$moduleDest   = Join-Path $SkillRoot 'tools/PSAppDeployToolkit.WinGet'
+$manifestPath = Join-Path $moduleDest 'PSAppDeployToolkit.WinGet.psd1'
+$configPath   = Join-Path $SkillRoot 'config.json'
+
+$installedTag = $null
+if (Test-Path $configPath) {
+    $cfg = Get-Content $configPath -Raw | ConvertFrom-Json
+    $installedTag = $cfg.tooling.winGetModuleVersion
+}
+
+$latestTag = $null
+try { $latestTag = (Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest").tag_name } catch { }
+
+$outPath = if ($PackagePath) { Join-Path $PackagePath 'PSAppDeployToolkit.WinGet' } else { $moduleDest }
+
+function Copy-ToPackage {
+    if (-not $PackagePath) { return }
+    Remove-Item $outPath -Recurse -Force -ErrorAction SilentlyContinue
+    Copy-Item $moduleDest $outPath -Recurse -Force
+}
+
+if ((Test-Path $manifestPath) -and $latestTag -and ($installedTag -eq $latestTag)) {
+    Copy-ToPackage
+    return [pscustomobject]@{ Action = 'AlreadyCurrent'; Version = $latestTag; Path = $outPath }
+}
+
+if (-not $latestTag -and (Test-Path $manifestPath)) {
+    Copy-ToPackage
+    return [pscustomobject]@{ Action = 'AlreadyCurrent'; Version = $installedTag; Path = $outPath }
+}
+
+$tag = if ($latestTag) { $latestTag } else { $fallbackTag }
+try {
+    $downloadUrl = if ($latestTag) {
+        $rel   = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest"
+        $asset = $rel.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
+        if (-not $asset) { throw "Release asset '$assetName' not found in release $tag." }
+        $asset.browser_download_url
+    } else {
+        $fallbackUrl
+    }
+
+    $tmpZip = Join-Path $env:TEMP "PSADTWinGet-$tag.zip"
+    $tmpDir = Join-Path $env:TEMP 'PSADTWinGet-extract'
+    Invoke-WebRequest $downloadUrl -OutFile $tmpZip -UseBasicParsing
+
+    $zipBytes = [System.IO.File]::ReadAllBytes($tmpZip)
+    if ($zipBytes[0] -ne 0x50 -or $zipBytes[1] -ne 0x4B) { throw "Downloaded file is not a valid ZIP (missing PK header)." }
+
+    Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    Expand-Archive $tmpZip -DestinationPath $tmpDir -Force
+
+    $src = Join-Path $tmpDir 'PSAppDeployToolkit.WinGet'
+    if (-not (Test-Path $src)) { throw "Expected folder 'PSAppDeployToolkit.WinGet' not found inside $assetName." }
+
+    Remove-Item $moduleDest -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item (Split-Path $moduleDest -Parent) -ItemType Directory -Force | Out-Null
+    Copy-Item $src $moduleDest -Recurse -Force
+    Remove-Item $tmpZip, $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+
+    & (Join-Path $PSScriptRoot 'Set-PsadtConfig.ps1') -SkillRoot $SkillRoot -Updates @{ 'tooling.winGetModuleVersion' = $tag }
+
+    Copy-ToPackage
+    $action = if ($installedTag) { 'Updated' } else { 'Downloaded' }
+    return [pscustomobject]@{ Action = $action; Version = $tag; Path = $outPath }
+}
+catch {
+    Remove-Item (Join-Path $env:TEMP "PSADTWinGet-$tag.zip") -Force -ErrorAction SilentlyContinue
+    if (Test-Path $manifestPath) {
+        Copy-ToPackage
+        return [pscustomobject]@{ Action = 'AlreadyCurrent'; Version = $installedTag; Path = $outPath }
+    }
+    return [pscustomobject]@{ Action = 'UpdateFailed'; Version = $null; Path = $moduleDest; Error = "$_" }
+}

--- a/scripts/New-PsadtEntraApp.ps1
+++ b/scripts/New-PsadtEntraApp.ps1
@@ -160,13 +160,16 @@ function Get-DeviceCodeToken([string]$Tenant, [string]$Scope) {
                 device_code = $dc.device_code
             } -ErrorAction Stop
         } catch {
+            # OAuth token endpoint errors return { "error": "<string>", "error_description": "..." }
+            # so Get-GraphError returns the string directly (not a .code/.message object).
             $e = Get-GraphError $_
-            switch ($e.error) {
-                'authorization_pending' { continue }
-                'slow_down'             { $interval += 5; continue }
+            $eCode = if ($e -is [string]) { $e } else { [string]$e.error }
+            switch ($eCode) {
+                'authorization_pending'  { continue }
+                'slow_down'              { $interval += 5; continue }
                 'authorization_declined' { throw "Sign-in was declined in the browser." }
-                'expired_token'         { throw "The device code expired before sign-in completed. Re-run the script." }
-                default                 { if ($e.code -eq 'Unknown' -and $e.message -match 'pending') { continue }; throw $e.message }
+                'expired_token'          { throw "The device code expired before sign-in completed. Re-run the script." }
+                default                  { if ($eCode -match 'pending') { continue }; throw ($e | Out-String) }
             }
         }
     }

--- a/scripts/New-PsadtEntraApp.ps1
+++ b/scripts/New-PsadtEntraApp.ps1
@@ -85,10 +85,11 @@ $Scopes = 'Application.ReadWrite.All AppRoleAssignment.ReadWrite.All offline_acc
 $GraphBase = 'https://graph.microsoft.com/v1.0'
 
 # WAM (Windows broker) is the preferred interactive sign-in; device code is the fallback.
-# MSAL wants fully-qualified scopes (openid/profile/offline_access are added automatically).
+# offline_access must be included explicitly - MSAL does NOT add OIDC scopes automatically for WAM.
 $WamScopes = @(
     'https://graph.microsoft.com/Application.ReadWrite.All'
     'https://graph.microsoft.com/AppRoleAssignment.ReadWrite.All'
+    'offline_access'
 )
 # Pinned, known-good MSAL.NET broker package set (auto-located or downloaded once).
 # Abstractions is a transitive dependency of the client and must be loaded alongside it.

--- a/scripts/New-PsadtEntraApp.ps1
+++ b/scripts/New-PsadtEntraApp.ps1
@@ -55,10 +55,26 @@ param(
     [string]$TenantId = 'organizations',
     [ValidateRange(1, 24)][int]$SecretValidMonths = 12,
     [switch]$Force,
-    [switch]$UseDeviceCode
+    [switch]$UseDeviceCode,
+    # Certificate-based auth (preferred over client secret): pass the thumbprint of a cert already in
+    # Cert:\CurrentUser\My. The cert's public key is uploaded to the app; no client secret is created.
+    [switch]$UseCertificate,
+    [string]$CertThumbprint
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Validate cert early (fail before any network calls)
+$certObj = $null
+if ($UseCertificate) {
+    if ([string]::IsNullOrWhiteSpace($CertThumbprint)) {
+        throw "-CertThumbprint is required with -UseCertificate. List available certs: Get-ChildItem Cert:\CurrentUser\My | Select Subject,Thumbprint,NotAfter"
+    }
+    $certObj = Get-Item "Cert:\CurrentUser\My\$CertThumbprint" -ErrorAction SilentlyContinue
+    if (-not $certObj) { throw "Certificate not found: Cert:\CurrentUser\My\$CertThumbprint" }
+    if ($certObj.NotAfter -lt (Get-Date)) { throw "Certificate has expired ($($certObj.NotAfter.ToString('yyyy-MM-dd'))). Create a new cert." }
+    if (-not $certObj.HasPrivateKey) { throw "Certificate Cert:\CurrentUser\My\$CertThumbprint has no private key - cannot sign client assertions." }
+}
 
 # --- Constants ---------------------------------------------------------------------------------------
 $AppDisplayName = 'PSADT Intune Upload'                       # fixed by design
@@ -346,6 +362,20 @@ if ($existing) {
     Write-Ok "Created app (objectId $($app.id), appId $($app.appId))"
 }
 
+# 3b. Upload certificate public key (if -UseCertificate) -----------------------------------------------
+if ($UseCertificate) {
+    Write-Info "Uploading certificate credential (thumbprint $CertThumbprint)..."
+    Invoke-WithRetry { Invoke-Graph PATCH "$GraphBase/applications/$($app.id)" -Headers $H -Body @{
+        keyCredentials = @(@{
+            type        = 'AsymmetricX509Cert'
+            usage       = 'Verify'
+            key         = [Convert]::ToBase64String($certObj.GetRawCertData())
+            displayName = 'PSADT Intune Automation'
+        })
+    } } | Out-Null
+    Write-Ok "Certificate uploaded (expires $($certObj.NotAfter.ToString('yyyy-MM-dd')))."
+}
+
 # 4. Ensure a service principal for the app ------------------------------------------------------------
 Write-Step "Ensure service principal"
 $sp = (Invoke-Graph GET "$GraphBase/servicePrincipals?`$filter=appId eq '$($app.appId)'" -Headers $H).value | Select-Object -First 1
@@ -388,35 +418,54 @@ if ($already) {
     }
 }
 
-# 6. Create a client secret ----------------------------------------------------------------------------
-Write-Step "Create client secret (valid $SecretValidMonths month(s))"
-$expires = (Get-Date).AddMonths($SecretValidMonths)
-$pwdResult = Invoke-Graph POST "$GraphBase/applications/$($app.id)/addPassword" -Headers $H -Body @{
-    passwordCredential = @{ displayName = 'PSADT upload secret'; endDateTime = $expires.ToString('o') }
+# 6. Credential: certificate (preferred) or client secret ----------------------------------------------
+$secret = $null
+$credExpires = $null
+if ($UseCertificate) {
+    Write-Step "Credential: certificate (uploaded in step 3b - no client secret created)"
+    $credExpires = $certObj.NotAfter
+    Write-Ok "Auth will use certificate $CertThumbprint (expires $($credExpires.ToString('yyyy-MM-dd')))."
+} else {
+    Write-Step "Create client secret (valid $SecretValidMonths month(s))"
+    $credExpires = (Get-Date).AddMonths($SecretValidMonths)
+    $pwdResult = Invoke-Graph POST "$GraphBase/applications/$($app.id)/addPassword" -Headers $H -Body @{
+        passwordCredential = @{ displayName = 'PSADT upload secret'; endDateTime = $credExpires.ToString('o') }
+    }
+    $secret = ConvertTo-SecureString $pwdResult.secretText -AsPlainText -Force
+    Write-Ok "Secret created (expires $($credExpires.ToString('yyyy-MM-dd'))). It is never displayed - stored encrypted."
 }
-$secret = ConvertTo-SecureString $pwdResult.secretText -AsPlainText -Force
-Write-Ok "Secret created (expires $($expires.ToString('yyyy-MM-dd'))). It is never displayed - stored encrypted."
 
-# 7. Persist to config (DPAPI for the secret) ----------------------------------------------------------
-Write-Step "Write config (config.json + DPAPI secret.dpapi)"
+# 7. Persist to config ---------------------------------------------------------------------------------
 $setCfg = Join-Path $PSScriptRoot 'Set-PsadtConfig.ps1'
-& $setCfg -SkillRoot $SkillRoot -Secret $secret -Updates @{
+$cfgUpdates = @{
     'intune.tenantId'      = $realTenant
     'intune.clientId'      = $app.appId
     'intune.uploadEnabled' = $true
-    'intune.secretRef'     = 'secret.dpapi'
+}
+if ($UseCertificate) {
+    Write-Step "Write config (config.json - thumbprint stored, no secret file)"
+    $cfgUpdates['intune.certThumbprint'] = $CertThumbprint
+    & $setCfg -SkillRoot $SkillRoot -Updates $cfgUpdates
+} else {
+    Write-Step "Write config (config.json + DPAPI secret.dpapi)"
+    $cfgUpdates['intune.secretRef'] = 'secret.dpapi'
+    & $setCfg -SkillRoot $SkillRoot -Secret $secret -Updates $cfgUpdates
 }
 Write-Ok "Saved to $(Join-Path $SkillRoot 'config.json')"
 
 # --- Summary -----------------------------------------------------------------------------------------
 Write-Host "`n----------------------------------------------------------------" -ForegroundColor DarkGray
 Write-Host "Done. Direct Intune upload is configured." -ForegroundColor Green
-Write-Host "  Tenant   : $realTenant"
-Write-Host "  Client   : $($app.appId)   ('$AppDisplayName')"
+Write-Host "  Tenant    : $realTenant"
+Write-Host "  Client    : $($app.appId)   ('$AppDisplayName')"
 Write-Host "  Permission: $RequiredAppRole  (consent: $(if($consentGranted){'granted'}else{'PENDING - grant in portal'}))"
-Write-Host "  Secret   : stored DPAPI-encrypted, expires $($expires.ToString('yyyy-MM-dd'))"
+if ($UseCertificate) {
+    Write-Host "  Auth      : certificate ($CertThumbprint), expires $($credExpires.ToString('yyyy-MM-dd'))" -ForegroundColor Cyan
+} else {
+    Write-Host "  Auth      : client secret, DPAPI-encrypted, expires $($credExpires.ToString('yyyy-MM-dd'))"
+}
 if (-not $consentGranted) {
-    Write-Host "  ACTION   : grant admin consent in the portal before the first upload." -ForegroundColor Yellow
+    Write-Host "  ACTION    : grant admin consent in the portal before the first upload." -ForegroundColor Yellow
 }
 Write-Host "Next: build a package; the upload step (Phase 7.5) will use this app." -ForegroundColor Gray
 Write-Host "----------------------------------------------------------------`n" -ForegroundColor DarkGray
@@ -426,6 +475,7 @@ Write-Host "----------------------------------------------------------------`n" 
     ClientId       = $app.appId
     AppObjectId    = $app.id
     ConsentGranted = $consentGranted
-    SecretExpires  = $expires
+    AuthMethod     = if ($UseCertificate) { 'Certificate' } else { 'ClientSecret' }
+    CredExpires    = $credExpires
     ConfigPath     = (Join-Path $SkillRoot 'config.json')
 }

--- a/tests/Get-WinGetModule.Tests.ps1
+++ b/tests/Get-WinGetModule.Tests.ps1
@@ -1,0 +1,130 @@
+BeforeAll {
+    . "$PSScriptRoot/_helpers.ps1"
+
+    function New-FakeModuleZip {
+        param([string]$Tag = 'v1.0.5')
+        $ver      = $Tag -replace '^v', ''
+        $fakeRoot = Join-Path $env:TEMP "PSADTfake-$([guid]::NewGuid().ToString('N'))"
+        $fakeSrc  = Join-Path $fakeRoot 'PSAppDeployToolkit.WinGet'
+        New-Item $fakeSrc -ItemType Directory -Force | Out-Null
+        Set-Content (Join-Path $fakeSrc 'PSAppDeployToolkit.WinGet.psd1') "@{ ModuleVersion = '$ver' }"
+        $zipPath = Join-Path $env:TEMP "PSADTWinGet-$Tag.zip"
+        Compress-Archive -Path $fakeSrc -DestinationPath $zipPath -Force
+        Remove-Item $fakeRoot -Recurse -Force -ErrorAction SilentlyContinue
+        return $zipPath
+    }
+
+    function New-ExistingModule {
+        param([string]$Root, [string]$Tag = 'v1.0.5')
+        $ver     = $Tag -replace '^v', ''
+        $modPath = Join-Path $Root 'tools/PSAppDeployToolkit.WinGet'
+        New-Item $modPath -ItemType Directory -Force | Out-Null
+        Set-Content (Join-Path $modPath 'PSAppDeployToolkit.WinGet.psd1') "@{ ModuleVersion = '$ver' }"
+        @{ version = 1; tooling = @{ winGetModuleVersion = $Tag } } |
+            ConvertTo-Json -Depth 5 | Set-Content (Join-Path $Root 'config.json')
+    }
+}
+
+Describe 'Get-WinGetModule' {
+    BeforeEach {
+        $script:root = New-TempSkillRoot
+        $script:run  = { . (Join-Path $script:root 'scripts/Get-WinGetModule.ps1') -SkillRoot $script:root }
+    }
+    AfterEach {
+        Remove-TempSkillRoot $script:root
+        Remove-Item "$env:TEMP\PSADTWinGet-*.zip"  -Force -ErrorAction SilentlyContinue
+        Remove-Item "$env:TEMP\PSADTWinGet-extract" -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'downloads the module when missing and records version in config' {
+        $null = New-FakeModuleZip -Tag 'v1.0.5'  # pre-builds the zip the mock won't write
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            @{ tag_name = 'v1.0.5'; assets = @(@{ name = 'PSAppDeployToolkit.WinGet.zip'; browser_download_url = 'https://example.com/fake.zip' }) }
+        }
+        Mock -CommandName Invoke-WebRequest -MockWith { }  # zip already at $tmpZip path
+
+        $r = & $script:run
+
+        Should -Invoke Invoke-WebRequest -Times 1
+        $r.Action  | Should -Be 'Downloaded'
+        $r.Version | Should -Be 'v1.0.5'
+        (Test-Path (Join-Path $script:root 'tools/PSAppDeployToolkit.WinGet/PSAppDeployToolkit.WinGet.psd1')) | Should -BeTrue
+        $cfg = Get-Content (Join-Path $script:root 'config.json') -Raw | ConvertFrom-Json
+        $cfg.tooling.winGetModuleVersion | Should -Be 'v1.0.5'
+    }
+
+    It 'is a no-op when present and version matches config' {
+        New-ExistingModule -Root $script:root -Tag 'v1.0.5'
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            @{ tag_name = 'v1.0.5'; assets = @(@{ name = 'PSAppDeployToolkit.WinGet.zip'; browser_download_url = 'https://example.com/fake.zip' }) }
+        }
+        Mock -CommandName Invoke-WebRequest -MockWith { }
+
+        $r = & $script:run
+
+        Should -Invoke Invoke-WebRequest -Times 0
+        $r.Action | Should -Be 'AlreadyCurrent'
+    }
+
+    It 'copies the module into PackagePath and returns its path' {
+        New-ExistingModule -Root $script:root -Tag 'v1.0.5'
+        $pkgPath = Join-Path $env:TEMP "psadt-pkg-$([guid]::NewGuid().ToString('N'))"
+        New-Item $pkgPath -ItemType Directory -Force | Out-Null
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            @{ tag_name = 'v1.0.5'; assets = @(@{ name = 'PSAppDeployToolkit.WinGet.zip'; browser_download_url = 'https://example.com/fake.zip' }) }
+        }
+
+        $r = . (Join-Path $script:root 'scripts/Get-WinGetModule.ps1') -SkillRoot $script:root -PackagePath $pkgPath
+
+        (Test-Path (Join-Path $pkgPath 'PSAppDeployToolkit.WinGet/PSAppDeployToolkit.WinGet.psd1')) | Should -BeTrue
+        $r.Path | Should -Be (Join-Path $pkgPath 'PSAppDeployToolkit.WinGet')
+        Remove-Item $pkgPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'falls back gracefully when GitHub is unreachable but module already exists' {
+        New-ExistingModule -Root $script:root -Tag 'v1.0.5'
+        Mock -CommandName Invoke-RestMethod -MockWith { throw 'no network' }
+        Mock -CommandName Invoke-WebRequest -MockWith { }
+
+        $r = & $script:run
+
+        Should -Invoke Invoke-WebRequest -Times 0
+        $r.Action | Should -Be 'AlreadyCurrent'
+    }
+
+    It 'falls back to the hardcoded URL when offline and module is missing' {
+        $null = New-FakeModuleZip -Tag 'v1.0.5'
+        Mock -CommandName Invoke-RestMethod -MockWith { throw 'no network' }
+        Mock -CommandName Invoke-WebRequest -MockWith { }
+
+        $r = & $script:run
+
+        Should -Invoke Invoke-WebRequest -Times 1
+        $r.Action  | Should -Be 'Downloaded'
+        $r.Version | Should -Be 'v1.0.5'
+    }
+
+    It 'returns UpdateFailed when download fails and no module exists' {
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            @{ tag_name = 'v1.0.5'; assets = @(@{ name = 'PSAppDeployToolkit.WinGet.zip'; browser_download_url = 'https://example.com/fake.zip' }) }
+        }
+        Mock -CommandName Invoke-WebRequest -MockWith { throw 'download failed' }
+
+        $r = & $script:run
+
+        $r.Action | Should -Be 'UpdateFailed'
+    }
+
+    It 'returns an object with Action, Version, and Path properties' {
+        New-ExistingModule -Root $script:root -Tag 'v1.0.5'
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            @{ tag_name = 'v1.0.5'; assets = @(@{ name = 'PSAppDeployToolkit.WinGet.zip'; browser_download_url = 'https://example.com/fake.zip' }) }
+        }
+
+        $r = & $script:run
+
+        $r.PSObject.Properties.Name | Should -Contain 'Action'
+        $r.PSObject.Properties.Name | Should -Contain 'Version'
+        $r.PSObject.Properties.Name | Should -Contain 'Path'
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds capabilities covering common real-world packaging scenarios and hardens the Phase 7.5 upload scripts with certificate auth and two bug fixes:

1. **Full WinGet deployment support** via the PSAppDeployToolkit.WinGet extension module
2. **MSI Icon table logo extraction** as a fallback when a web logo source is unavailable
3. **Em-dash anti-pattern scope clarification** (minor doc fix)
4. **Certificate-based authentication for Phase 7.5** — no secrets at rest
5. **Bug fix: device-code polling `ScriptHalted`** on first poll
6. **Bug fix: WAM missing `offline_access` scope**

---

## 1. WinGet support (PSAppDeployToolkit.WinGet)

Many enterprise apps are most reliably packaged as WinGet deployments (no local installer to maintain, automatic version tracking). The skill now covers the complete WinGet lifecycle end-to-end.

### New script: `scripts/Get-WinGetModule.ps1`

Downloads and caches the latest PSAppDeployToolkit.WinGet release from GitHub into `tools/`, then copies it into a target package folder. Re-triggerable to update the module. Skipped entirely for MSI/EXE packages.

### New test: `tests/Get-WinGetModule.Tests.ps1`

Pester 5 tests for `Get-WinGetModule.ps1` covering: GitHub API response parsing, cache reuse, module copy, and package provisioning.

### SKILL.md additions (all phases)

| Phase | Addition |
|---|---|
| 0 | `Get-WinGetModule.ps1` listed as a WinGet-only prerequisite |
| 1 Q2 | WinGet as installer type option; follow-up questions for Package ID / scope / version; Q3 skipped for WinGet |
| 2b-WinGet | New research stream replacing stream b: `Find-ADTWinGetPackage` discovery, manifest lookup, portable package path conventions |
| 3 | Extension module provisioning after scaffold; PSADT auto-loader note |
| 4a | Install pattern: `Repair-ADTWinGetPackageManager` + `Install-ADTWinGetPackage -Scope Machine` |
| 4b | Uninstall pattern: `Uninstall-ADTWinGetPackage` |
| 4c | Repair pattern: `Repair-ADTWinGetPackage` with uninstall+reinstall fallback |
| 5 | Check 4 (WinGet module present in package); Check 3 note (use test stub — a live WinGet install will trigger) |
| 7 | WinGet dossier requirements (`AppVersion = 'Latest'`, no installer hash, detection via registry/file) |
| Anti-patterns | WinGet-specific entries (see below) |

**WinGet anti-patterns added:**

- Using `Get-ADTWinGetPackage` in a detection script — the module is not present on the device at detection time
- `-Scope User` in Intune deployments — SYSTEM context has no mounted user hive; always use `-Scope Machine`
- Skipping `Repair-ADTWinGetPackageManager` before install — WinGet may be absent or outdated on managed devices
- Mixing `Install-ADTWinGetPackage` with `Start-ADTProcess`/`Start-ADTMsiProcess` in the same hook
- Using bare cmdlet names without the `ADT` prefix (`Install-WinGetPackage`, `Repair-WinGetPackageManager`, etc.) — those bypass PSADT logging, error handling, and session management

The v3 leftover scan in SKILL.md also now flags bare `Assert-WinGetPackageManager`, `Get-WinGetPackage`, `Install-WinGetPackage`, `Uninstall-WinGetPackage`, `Repair-WinGetPackage`, and `Repair-WinGetPackageManager`.

---

## 2. MSI Icon table logo extraction

Adds a 4-priority logo source list to Phase 7 and a technique for extracting the app logo directly from the MSI installer when no web source is unavailable:

| Priority | Source |
|---|---|
| 1 | Microsoft Learn assets (Microsoft products only) |
| 2 | Official vendor/project site |
| 3 | Wikimedia Commons |
| 4 | MSI Icon table (COM export + raw ICO binary parse) |

The MSI Icon table fallback is documented with a working inline C# class (`IcoDibReader`) that handles the .NET Framework 4.x limitation where `System.Drawing.Icon` silently falls back to 48×48 when the 256×256 frame inside the `.ico` is PNG-compressed. The class parses the ICO binary directly and handles the BMP DIB case (vertical row flip, `BITMAPINFOHEADER` skip, 2× height stored in the header).

This is compatible with the existing `AppIcon.png` SHA256 blocklist and corner-pixel alpha check.

---

## 3. Em-dash anti-pattern scope (minor doc fix)

Clarified that the em-dash/smart-quote anti-pattern applies **anywhere in the script file — including comments**, not just in double-quoted strings. This matches the actual PS5.1 parse error behavior (the parser rejects non-ASCII even in comment tokens).

---

## 4. Certificate-based authentication for Phase 7.5

The existing Phase 7.5 upload scripts only supported client secrets (DPAPI-encrypted). This adds a full certificate credential path as the preferred alternative — no secret to rotate, no DPAPI portability constraint, private key never leaves the machine.

### `New-PsadtEntraApp.ps1` — new `-UseCertificate` / `-CertThumbprint` params

```powershell
pwsh scripts/New-PsadtEntraApp.ps1 -UseCertificate -CertThumbprint <thumb>
```

- Validates the cert early (present, not expired, has private key) before any network calls
- Uploads the cert public key to the app registration as an `AsymmetricX509Cert` key credential via `PATCH /applications/{id}` — no proof-of-possession required for newly created apps
- Skips client secret creation entirely; no `secret.dpapi` file is created
- Stores `intune.certThumbprint` in `config.json` (gitignored)
- Output object updated: `AuthMethod` (`Certificate` / `ClientSecret`), `CredExpires`

### `Get-GraphToken.ps1` — RFC 7523 signed JWT client assertion

When `intune.certThumbprint` is present in config, the token is acquired by:

1. Loading the cert from `Cert:\CurrentUser\My\<thumbprint>`
2. Building a signed JWT (`alg: RS256`, `x5t` header = base64url of the 20-byte SHA-1 thumbprint)
3. Submitting via `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`

The DPAPI secret path is preserved as a fallback. Call sites are unchanged — both paths return the same `{ Token, ExpiresOn, TenantId, ClientId }` object.

### `Get-PsadtConfig.ps1` — updated `uploadEnabled` validation

When `intune.certThumbprint` is set: validates the cert exists in `Cert:\CurrentUser\My`. Otherwise: validates `secret.dpapi` exists on disk. The two credential types are mutually exclusive in validation.

### `references/app-registration.md`

- Cert bootstrap one-liner added at the top
- Step 3 split into Option A (cert, preferred) / Option B (client secret)
- Step 4 split into cert thumbprint config vs DPAPI secret config

Commit: `453536d`

---

## 5. Bug fix: device-code polling `ScriptHalted` on first poll

**Symptom:** Script threw `ScriptHalted` at the device-code polling catch block on the very first poll, before the user could complete browser sign-in.

**Root cause:** `Get-DeviceCodeToken` used `Get-GraphError` to parse OAuth token endpoint errors, then did `switch ($e.error)`. The OAuth token endpoint returns `{"error": "authorization_pending", ...}` where `error` is a top-level **string** — not an object. `Get-GraphError` returns that string directly, so `$e` is already the string `"authorization_pending"`. Accessing `.error` on a string returns `$null`, so the switch always fell to `default`, which called `throw $e.message` — `.message` on a string is also `$null` → `throw $null` → `ScriptHalted`.

> Note: `Get-GraphError` correctly returns an object for Graph API errors (where `error` is a nested JSON object). Only OAuth token endpoint responses were affected.

**Fix** — extract the error code defensively before the switch:

```powershell
$eCode = if ($e -is [string]) { $e } else { [string]$e.error }
switch ($eCode) {
    'authorization_pending'  { continue }
    'slow_down'              { $interval += 5; continue }
    'authorization_declined' { throw "Sign-in was declined in the browser." }
    'expired_token'          { throw "Device code expired. Re-run the script." }
    default                  { if ($eCode -match 'pending') { continue }; throw ($e | Out-String) }
}
```

Commit: `e87c2aa`

---

## 6. Bug fix: WAM missing `offline_access` scope

**Symptom:** WAM (MSAL broker) sign-in failed with `MsalClientException ErrCode 5376: At least one scope needs to be requested for this authentication flow`, causing an immediate fallback to device code.

**Root cause:** `$WamScopes` only contained fully-qualified Graph permission scopes. A code comment stated that MSAL adds OIDC scopes automatically — this is incorrect for the WAM broker flow. MSAL requires `offline_access` to be listed explicitly.

**Fix:**

```powershell
$WamScopes = @(
    'https://graph.microsoft.com/Application.ReadWrite.All'
    'https://graph.microsoft.com/AppRoleAssignment.ReadWrite.All'
    'offline_access'    # required explicitly — MSAL does NOT add this automatically for WAM
)
```

Commit: `929adda`

---

## Testing

- `Get-WinGetModule.ps1` covered by `tests/Get-WinGetModule.Tests.ps1` (Pester 5)
- SKILL.md additions validated against the PSADT v4.1.8 module cmdlet signatures
- WinGet patterns tested against live Intune SYSTEM-context deployments
- Certificate auth tested end-to-end: app creation, cert credential upload, JWT assertion, Graph token, `Invoke-IntuneWin32Upload.ps1` live upload
- Device-code polling fix verified: sign-in now waits correctly for browser completion
- WAM fix verified: broker sign-in window opens successfully after adding `offline_access`

## Compatibility

No changes to existing MSI/EXE/MSIX workflows. WinGet support is strictly additive. Certificate auth is opt-in via `-UseCertificate`; the DPAPI secret path is fully preserved as a fallback.
