### PR TITLE
feat(skill): browser-extension force-install packages (Edge/Chrome/Firefox) (0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.14.0 — 2026-06-15 — Browser-extension force-install packages (Edge / Chrome / Firefox)
+
+### Added
+- **`scripts/New-BrowserExtensionPackage.ps1`** — one-call generator for a new opt-in package type:
+  force-install browser extensions via enterprise **policy registry keys** (no vendor installer, `Files\`
+  empty, ESP-safe, no reboot). Each browser then pulls the extension from its own store. Supports **multiple
+  extensions per package** across Edge / Chrome / Firefox. Writes the launcher (data model + 3 hooks), the
+  Extensions module (4 helpers) and the detection script.
+- **Guide Appendix O** — model, Phase-2 store-availability research (per-store IDs: Chrome/Edge 32-char `a-p`,
+  Firefox `id@domain` + AMO slug), verbatim registry reference, generator usage, helpers, hooks, the honest
+  detection model, dossier additions and anti-patterns.
+- SKILL.md control-plane: Gate-1 package-type option, Phase-2 research note, three anti-patterns, reference-
+  lookup line for Appendix O.
+
+### Notes
+- **Coexistence by design.** The Chromium helper computes the **next free `ExtensionInstallForcelist` index**
+  (never hard-codes `1`), dedupes by extension ID, and removes only its own entry — so multiple extension
+  packages share the key without clobbering. Firefox merges into the single `ExtensionSettings` JSON keyed by ID.
+- **Firefox `REG_MULTI_SZ` trap.** `ExtensionSettings` is written as `REG_MULTI_SZ`; a single-line `REG_SZ` is
+  silently ignored by current Firefox (Mozilla bug 1750233).
+- Verified: generated package passes the Phase-5 pre-flight **GREEN**; all four helpers validated against a
+  scratch registry hive (next-free index, idempotent add, selective remove, `REG_MULTI_SZ` merge incl.
+  remove-last cleanup); generator is 7-bit ASCII-clean.
+
 ## 0.13.1 — 2026-06-15 — Firewall policy body fixed against the live template (verified 201)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,12 +167,13 @@ psadt-deploy/
 │  ├─ Invoke-PsadtSystemTest.ps1    SYSTEM test loop (Phase 6)
 │  ├─ New-PsadtReport.ps1           HTML package report (Phase 8, always)
 │  ├─ New-MsiPackage.ps1            reusable MSI package generator (opt-in)
+│  ├─ New-BrowserExtensionPackage.ps1  browser-extension force-install generator (opt-in)
 │  ├─ New-PsadtEntraApp.ps1         Entra app bootstrap (WAM)
 │  ├─ Get-GraphToken.ps1            app-only Graph token (cert/DPAPI)
 │  ├─ _GraphCommon.ps1              shared Graph helpers (3 upload scripts)
 │  ├─ Invoke-IntuneWin32Upload.ps1  direct Intune upload (Phase 9)
 │  └─ Invoke-IntuneAppAssignment.ps1 opt-in Entra group assignment (Phase 10)
-├─ references/   guide (App. A-M) + Report-Template.html + app-registration.md
+├─ references/   guide (App. A-O) + Report-Template.html + app-registration.md
 ├─ tests/        Pester suite for the scripts
 ├─ tools/        (gitignored)  IntuneWinAppUtil.exe + WinGet module
 ├─ config.json   (gitignored)  machine-local settings (intune.* block)

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,10 @@ researched defaults; recommended option first.
 
 1. **Scope confirm** - app + exact version, installer type, source strategy (local / bundle into package /
    download at runtime). WinGet is strictly opt-in here: default to the native installer, never recommend or
-   auto-select WinGet even if a package exists. If WinGet is chosen, follow guide Appendix I.
+   auto-select WinGet even if a package exists. If WinGet is chosen, follow guide Appendix I. **Package type**
+   is part of this gate when ambiguous: native installer (default) · WinGet (opt-in, App. I) · script-only
+   fix/remediation (App. K) · **browser-extension force-install** (Edge/Chrome/Firefox via policy keys, App. O,
+   built by `scripts/New-BrowserExtensionPackage.ps1`).
 2. **Deployment semantics** - target audience (Required / Available / both, + AAD groups), uninstall "what
    goes vs. what stays", repair strategy, reboot behaviour (never / 3010 / 1641). Pre-select defaults from
    the installer type. Group assignment is **opt-in**: only when the user wants it here do you create/assign
@@ -157,7 +160,9 @@ end. Resolve scope via decision gates 1 + 2 only; pre-fill every option from res
 concurrently, collect into the Phase-0.3 findings table, and show it before scaffold. Record per deployment
 type: switch, expected exit codes, log path, known leftovers. **Consult guide Appendix L (installer technologies
 + silent switches) BEFORE web-searching switches**; for a script-only fix/remediation/debloat package (no vendor
-installer) follow guide Appendix K instead of the normal installer flow. On a newer PSADT release, ALWAYS diff the
+installer) follow guide Appendix K instead of the normal installer flow. For a **browser-extension** package the
+research is store-availability + per-store IDs (Chrome/Edge 32-char `a-p`, Firefox `id@domain` + AMO slug), not
+silent switches - guide Appendix O.2. On a newer PSADT release, ALWAYS diff the
 release notes for renamed/deprecated/changed commands before building - never adopt a version by number alone;
 verify the actually-used cmdlets with `Get-Command -Module PSAppDeployToolkit` (and `Get-Help <cmdlet>
 -Parameter *` for changed params). If divergent, recommend `Update-Module PSAppDeployToolkit -Force` before
@@ -297,6 +302,10 @@ Full symptom/HRESULT catalogue: guide Appendix A.
 - Claiming Intune "can't" put a cert in `TrustedPublisher` (it can - `RootCATrustedCertificates` CSP via Custom
   OMA-URI; the built-in template is the part that can't); multi-line/PEM base64 or a mismatched thumbprint in the
   OMA-URI value (-> `0x87d1fde8`); owning a cert in BOTH the package and a policy (they fight on uninstall/sync).
+- Browser extensions (App. O): Firefox `ExtensionSettings` as `REG_SZ` instead of `REG_MULTI_SZ` (silently
+  ignored); clobbering the whole forcelist key / hard-coding index `1` instead of merging at the next free index
+  (wipes other extension packages); a detection that claims the extension is "installed" rather than that the
+  policy is set.
 
 ## Reference lookup
 
@@ -307,4 +316,6 @@ learned · H direct Graph upload · **I WinGet packaging** · **J app-logo acqui
 **K script-only / remediation packages (ESP-safe)** · **L installer technologies + silent switches** ·
 **M group assignment (opt-in: config, naming, permissions)** ·
 **N certificate store deployment (driver-trust / TrustedPublisher; RootCATrustedCertificates CSP OMA-URI;
-`New-IntuneTrustedCertPolicy.ps1`)**.
+`New-IntuneTrustedCertPolicy.ps1`)** ·
+**O browser-extension force-install (opt-in: Edge/Chrome/Firefox policy keys, Firefox `REG_MULTI_SZ` trap,
+merge/selective-remove; `New-BrowserExtensionPackage.ps1`)**.

--- a/references/PSADTv4-Deployment-Guide.md
+++ b/references/PSADTv4-Deployment-Guide.md
@@ -1751,3 +1751,125 @@ Creating a configuration profile needs the Graph application role **`DeviceManag
 - **Assignment scope.** Assign the cert profile to the SAME group/scope as the app, or the silent driver install
   races a device without the trust.
 - **One owner only** (N.3). If you ship the policy, do NOT also import the cert in the package, and vice-versa.
+
+---
+
+## Appendix O: Browser extension force-install packages (opt-in)
+
+A distinct, recurring package type: deploy a **browser extension** to Edge / Chrome / Firefox. In the
+enterprise these are not "installed" - you set **policy registry keys** and each browser pulls the extension
+from its own store. So this is a **policy-only** package: no vendor installer, `Files\` empty, ESP-safe, no
+reboot. It is **opt-in** (Gate 1 package-type choice), never the default for a normal app.
+
+Generate the whole package in one call: **`scripts/New-BrowserExtensionPackage.ps1`** writes the launcher
+(data model + 3 hooks), the Extensions module (4 merge/remove helpers) and the detection script.
+
+### O.1 The model
+
+| | |
+|---|---|
+| Source | **Online store force-install only** (Chrome Web Store / Edge Add-ons / Firefox AMO). Self-hosted CRX/XPI is out of scope. |
+| Mechanism | Policy registry keys (O.3). Browser applies them on its next start; nothing is launched, no process closed. |
+| Deployment types | Install = set keys (merge), Uninstall = remove ONLY own keys, Repair = re-apply (idempotent). |
+| Coexistence | Multiple extension packages share the same policy keys - **merge**, never clobber; remove only own entries (O.5). |
+| Detection | Verifies the **policy is set** (registry), NOT that the browser actually loaded the extension (O.7). |
+
+### O.2 Phase-2 research (replaces the silent-switch research)
+
+Find the extension in each store the customer uses and capture the per-store ID:
+- **Chrome Web Store** - ID = 32 chars `a-p`, from the URL `.../detail/<slug>/<ID>`.
+- **Edge Add-ons** - ID = 32 chars `a-p`, from `microsoftedge.microsoft.com/addons/detail/<slug>/<ID>`. (Edge can also load Chrome Web Store IDs if the org allows other stores; default is the Edge ID.)
+- **Firefox AMO** - ID = `name@domain` or a GUID (from the listing / the `.xpi` manifest), PLUS the **AMO slug** (`addons.mozilla.org/.../addon/<slug>/`). The install_url is `https://addons.mozilla.org/firefox/downloads/latest/<slug>/latest.xpi`.
+
+Set only the browsers that actually carry the extension. Not in a store -> it cannot be force-installed this way
+(only self-hosted, which is out of scope) - say so.
+
+### O.3 Registry reference (verbatim - get these wrong and it silently fails)
+
+| Browser | HKLM path | Value | Type | Format |
+|---|---|---|---|---|
+| Chrome | `SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist` | index `"1","2",...` | `REG_SZ` | `"<id>;https://clients2.google.com/service/update2/crx"` |
+| Edge | `SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist` | index `"1","2",...` | `REG_SZ` | `"<id>;https://edge.microsoft.com/extensionwebstorebase/v1/crx"` |
+| Firefox | `SOFTWARE\Policies\Mozilla\Firefox` | `ExtensionSettings` | **`REG_MULTI_SZ`** | JSON `{"<id>":{"installation_mode":"force_installed","install_url":"https://addons.mozilla.org/firefox/downloads/latest/<slug>/latest.xpi"}}` |
+
+- **Firefox MUST be `REG_MULTI_SZ`.** A single-line `REG_SZ` is silently ignored by current Firefox
+  (Mozilla bug 1750233). In PowerShell: `New-ItemProperty -PropertyType MultiString`.
+- **Chrome/Edge values are keyed by index NAME but matched by VALUE.** The browser only reads the values, not
+  the names - so the index is just a unique label.
+- **Removing a Chrome/Edge forcelist entry makes the browser auto-uninstall the extension** - that IS the
+  uninstall path. Firefox: remove the id from the JSON.
+- HKLM policy keys are not WOW-redirected -> run detection 64-bit (Run as 32-bit = No).
+
+### O.4 Generate the package (one call, in-process)
+
+`-Extensions` is an array of hashtables, so call the generator **in-process** (not `pwsh -File`, which
+stringifies the array):
+```powershell
+$exts = @(
+    @{ Name='uBlock Origin'
+       Edge   = @{ Id='odfafepnkmbhccpbejgmiehpchacaeak' }
+       Chrome = @{ Id='cjpalhdlnbpafiamejdnhcphjbkeiagm' }
+       Firefox= @{ Id='uBlock0@raymondhill.net'; Slug='ublock-origin' } }   # Slug -> AMO install_url is derived
+    @{ Name='1Password'
+       Edge   = @{ Id='dppgmdbiimibapkepcbdbmkaabgiofem' }
+       Chrome = @{ Id='aeblfdkhhhdcdjpifhhbdiojplfjncoa' } }                 # Edge+Chrome only (no Firefox set)
+)
+& scripts/New-BrowserExtensionPackage.ps1 -Name 'BrowserExtensions-Standard' `
+    -AppName 'Browser Extensions (Standard Set)' -Extensions $exts
+```
+The data model lands at the top of `Invoke-AppDeployToolkit.ps1` as `$script:BrowserExtensions` (the single
+source of truth for all three hooks AND the detection script). Each entry sets at least one browser; Firefox
+takes either `Slug` (install_url derived) or an explicit `InstallUrl`.
+
+### O.5 Extensions helpers (merge + selective remove)
+
+Written into `PSAppDeployToolkit.Extensions.psm1`:
+- `Set-ADTChromiumForcelistEntry -Browser Edge|Chrome -ExtensionId <id>` - reads ALL existing values, **next
+  free numeric index** (never hard-codes `1`), idempotent (skips if the id is already present), foreign entries
+  untouched.
+- `Remove-ADTChromiumForcelistEntry -Browser Edge|Chrome -ExtensionId <id>` - deletes only the value whose data
+  is `"<id>;..."`.
+- `Set-ADTFirefoxExtensionSetting -ExtensionId <id> -InstallUrl <xpi>` - reads `ExtensionSettings`
+  (`REG_MULTI_SZ` -> join lines -> `ConvertFrom-Json`), merges the id as `force_installed`, writes back as
+  `REG_MULTI_SZ`.
+- `Remove-ADTFirefoxExtensionSetting -ExtensionId <id>` - removes the id from the JSON; deletes the whole value
+  when it becomes empty. (Emptiness is tested via `ConvertTo-Json` == `{}`, NOT `PSObject.Properties.Count` - a
+  PSCustomObject reports a phantom empty-named property after the last note property is removed.)
+
+### O.6 Hooks
+
+Install loops the data model and calls the matching `Set-` helper per browser; Uninstall calls the `Remove-`
+helpers; Repair re-applies (idempotent). No `Show-ADTInstallationWelcome`/process-close (policy-only). Generated
+for you - do not hand-roll.
+
+### O.7 Detection + Intune wiring
+
+`Detect-<Name>.ps1` embeds the same data model and checks every managed entry is present (forcelist contains
+`"<id>;*"`; Firefox JSON has the id with `installation_mode=force_installed`). Contract: stdout + `exit 0` when
+ALL present; no output + `exit 0` otherwise.
+
+**Honest model:** detection proves the **policy is set**, not that each browser/profile has actually downloaded
+the extension (that is online + per-user and outside the package's control). Do NOT write a detection that
+claims "extension installed".
+
+Intune: Install behavior **System**; `-DeployMode Silent`; detection = **script rule**, Run as 32-bit = No; no
+reboot; ESP-safe (fast, registry-only). Pre-flight (Phase 5) passes unchanged - the acid-test sees the three
+hooks + all four helpers called.
+
+### O.8 Dossier additions
+
+Reuse the standard `$meta` fields - no new template tokens:
+- `DescMdDe/En`: list the managed extensions and which browsers each targets; note "managed by your
+  organization" appears in the browser.
+- `RuleFormat` / detection note: "policy present (registry); the browser pulls the extension from its store -
+  requires network + store reachability."
+- `DependenciesNote`: none (the extension is fetched online by the browser).
+
+### O.9 Anti-patterns
+
+- Firefox `ExtensionSettings` as `REG_SZ` (silently ignored) - it MUST be `REG_MULTI_SZ`.
+- Clobbering the whole forcelist key / overwriting `ExtensionSettings` instead of merging - destroys other
+  packages' extensions. Always next-free-index / JSON-merge, and remove ONLY own entries.
+- Hard-coding forcelist index `1` - collides with other extension packages.
+- Detection that asserts the extension is installed in the profile (it can only assert the policy is set).
+- Self-hosted CRX/XPI dressed up as "store force-install" - different mechanism, out of scope here.

--- a/scripts/New-BrowserExtensionPackage.ps1
+++ b/scripts/New-BrowserExtensionPackage.ps1
@@ -1,0 +1,708 @@
+#Requires -Modules PSAppDeployToolkit
+<#
+    New-BrowserExtensionPackage.ps1 - reusable PSADT v4.1.8 generator for browser-extension
+    force-install packages (Microsoft Edge / Google Chrome / Mozilla Firefox).
+
+    These are POLICY-ONLY packages: no vendor installer, no bundled payload - the package only sets
+    enterprise policy registry keys, and each browser then pulls the extension from its own store
+    (Chrome Web Store / Edge Add-ons / Firefox AMO). ESP-safe, no reboot.
+
+    The generator scaffolds the template and writes (English/ASCII only):
+      - Invoke-AppDeployToolkit.ps1  (data model + Install/Uninstall/Repair hooks)
+      - PSAppDeployToolkit.Extensions\PSAppDeployToolkit.Extensions.psm1  (4 merge/remove helpers)
+      - Detect-<Name>.ps1            (verifies the policy is set; honest model)
+
+    See references/PSADTv4-Deployment-Guide.md Appendix O for the model, registry reference and
+    anti-patterns.
+
+    .PARAMETER Extensions
+    Array of hashtables, one per extension. Each MUST set at least one browser:
+        @{
+            Name    = 'uBlock Origin'                                  # display name (ASCII)
+            Edge    = @{ Id = 'odfafepnkmbhccpbejgmiehpchacaeak' }      # Edge Add-ons ID (optional)
+            Chrome  = @{ Id = 'cjpalhdlnbpafiamejdnhcphjbkeiagm' }      # Chrome Web Store ID (optional)
+            Firefox = @{ Id = 'uBlock0@raymondhill.net'; Slug = 'ublock-origin' }   # AMO id + slug (optional)
+        }
+    Firefox accepts either Slug (the AMO install_url is derived) OR an explicit InstallUrl.
+
+    .EXAMPLE
+    $exts = @(
+        @{ Name='uBlock Origin'
+           Edge=@{Id='odfafepnkmbhccpbejgmiehpchacaeak'}
+           Chrome=@{Id='cjpalhdlnbpafiamejdnhcphjbkeiagm'}
+           Firefox=@{Id='uBlock0@raymondhill.net'; Slug='ublock-origin'} }
+    )
+    pwsh scripts/New-BrowserExtensionPackage.ps1 -Name 'BrowserExtensions-Standard' `
+        -AppName 'Browser Extensions (Standard Set)' -Extensions $exts
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Name,                 # package folder + scaffold name (path-safe)
+    [Parameter(Mandatory)][string]$AppName,              # display name in $adtSession
+    [string]$AppVersion = '1.0',
+    [Parameter(Mandatory)][hashtable[]]$Extensions,      # see .PARAMETER Extensions
+    [string]$AppVendor = 'Browser Extensions',
+    [string]$Author,
+    [string]$PackageRoot,
+    [string]$Changelog = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Import-Module PSAppDeployToolkit -Force
+
+if (-not $PackageRoot) { $PackageRoot = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1')).Config.paths.packageRoot }
+if (-not $Author) {
+    $cfg = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1')).Config
+    if ($cfg) { $Author = "$($cfg.author.person), $($cfg.author.company)" }
+}
+$today = (Get-Item $PSCommandPath).LastWriteTime.ToString('yyyy-MM-dd')  # avoid Get-Date (sandbox)
+
+# --- Validate + normalize the extension list ------------------------------------------------------
+$chromiumIdPattern = '^[a-p]{32}$'
+$norm = foreach ($ext in $Extensions) {
+    if (-not $ext.ContainsKey('Name') -or [string]::IsNullOrWhiteSpace([string]$ext.Name)) {
+        throw "Each extension needs a Name."
+    }
+    $hasBrowser = $false
+    foreach ($b in 'Edge', 'Chrome', 'Firefox') { if ($ext.ContainsKey($b)) { $hasBrowser = $true } }
+    if (-not $hasBrowser) { throw "Extension '$($ext.Name)' sets no browser (need at least one of Edge/Chrome/Firefox)." }
+
+    foreach ($b in 'Edge', 'Chrome') {
+        if ($ext.ContainsKey($b)) {
+            $id = [string]$ext[$b].Id
+            if ([string]::IsNullOrWhiteSpace($id)) { throw "Extension '$($ext.Name)' $b is missing an Id." }
+            if ($id -notmatch $chromiumIdPattern) { Write-Warning "Extension '$($ext.Name)' $b Id '$id' is not a 32-char a-p store ID - double-check it." }
+        }
+    }
+    if ($ext.ContainsKey('Firefox')) {
+        $fid = [string]$ext.Firefox.Id
+        if ([string]::IsNullOrWhiteSpace($fid)) { throw "Extension '$($ext.Name)' Firefox is missing an Id." }
+        $furl = [string]$ext.Firefox.InstallUrl
+        if ([string]::IsNullOrWhiteSpace($furl)) {
+            $slug = [string]$ext.Firefox.Slug
+            if ([string]::IsNullOrWhiteSpace($slug)) { throw "Extension '$($ext.Name)' Firefox needs either Slug or InstallUrl." }
+            $furl = "https://addons.mozilla.org/firefox/downloads/latest/$slug/latest.xpi"
+        }
+        $ext.Firefox.InstallUrl = $furl
+    }
+    $ext
+}
+
+# --- Render the shared $BrowserExtensions literal (used by launcher AND detection) ----------------
+function ConvertTo-Literal([string]$s) { "'" + ($s -replace "'", "''") + "'" }
+$lines = foreach ($ext in $norm) {
+    $parts = @("Name = $(ConvertTo-Literal $ext.Name)")
+    if ($ext.ContainsKey('Edge'))    { $parts += "Edge = @{ Id = $(ConvertTo-Literal ([string]$ext.Edge.Id)) }" }
+    if ($ext.ContainsKey('Chrome'))  { $parts += "Chrome = @{ Id = $(ConvertTo-Literal ([string]$ext.Chrome.Id)) }" }
+    if ($ext.ContainsKey('Firefox')) { $parts += "Firefox = @{ Id = $(ConvertTo-Literal ([string]$ext.Firefox.Id)); InstallUrl = $(ConvertTo-Literal ([string]$ext.Firefox.InstallUrl)) }" }
+    "    @{ " + ($parts -join '; ') + " }"
+}
+$extLiteral = "@(`r`n" + ($lines -join "`r`n") + "`r`n)"
+
+# 1) Scaffold
+$pkg = Join-Path $PackageRoot $Name
+if (Test-Path $pkg) { Remove-Item $pkg -Recurse -Force }
+New-ADTTemplate -Destination $PackageRoot -Name $Name -Force | Out-Null
+
+# 2) Launcher
+$tpl = @'
+<#
+.SYNOPSIS
+PSAppDeployToolkit - Force-installs / removes browser extensions for __APPNAME__.
+.DESCRIPTION
+Policy-only package (no vendor installer): sets enterprise policy registry keys so Edge / Chrome /
+Firefox pull the configured extensions from their stores. Three deployment types (Install / Uninstall
+/ Repair) for Intune Win32 (PSADT v4.1.8). Custom helpers live in PSAppDeployToolkit.Extensions.
+.NOTES
+Changelog:
+__CHANGELOG__
+.LINK
+https://psappdeploytoolkit.com
+#>
+
+[CmdletBinding()]
+param
+(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Install', 'Uninstall', 'Repair')]
+    [System.String]$DeploymentType,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Auto', 'Interactive', 'NonInteractive', 'Silent')]
+    [System.String]$DeployMode,
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.SwitchParameter]$SuppressRebootPassThru,
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.SwitchParameter]$TerminalServerMode,
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.SwitchParameter]$DisableLogging
+)
+
+
+##================================================
+## MARK: Variables
+##================================================
+
+$adtSession = @{
+    AppVendor = '__APPVENDOR__'
+    AppName = '__APPNAME__'
+    AppVersion = '__APPVERSION__'
+    AppArch = 'x64'
+    AppLang = 'EN'
+    AppRevision = '01'
+    AppSuccessExitCodes = @(0)
+    AppRebootExitCodes = @(1641, 3010)
+    AppProcessesToClose = @()
+    AppScriptVersion = '0.1'
+    AppScriptDate = '__DATE__'
+    AppScriptAuthor = '__AUTHOR__'
+    RequireAdmin = $true
+
+    InstallName = ''
+    InstallTitle = ''
+
+    DeployAppScriptFriendlyName = $MyInvocation.MyCommand.Name
+    DeployAppScriptParameters = $PSBoundParameters
+    DeployAppScriptVersion = '4.1.8'
+}
+
+## Single source of truth for all three hooks + the detection script: the managed extensions.
+## Each entry sets at least one browser. Edge/Chrome use the policy ExtensionInstallForcelist; Firefox
+## uses the policy ExtensionSettings JSON. The helpers MERGE into shared policy keys and remove ONLY
+## their own entries, so multiple extension packages coexist on the same device.
+$script:BrowserExtensions = __EXTLITERAL__
+
+function Install-ADTDeployment
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    ##================================================
+    ## MARK: Pre-Install
+    ##================================================
+    $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
+
+    ## Policy-only: nothing to close. The browser applies the policy on its next start.
+    Show-ADTInstallationProgress
+
+    ##================================================
+    ## MARK: Install
+    ##================================================
+    $adtSession.InstallPhase = $adtSession.DeploymentType
+
+    foreach ($ext in $script:BrowserExtensions)
+    {
+        Write-ADTLogEntry -Message "Force-installing browser extension [$($ext.Name)]."
+        if ($ext.ContainsKey('Edge'))    { Set-ADTChromiumForcelistEntry -Browser Edge   -ExtensionId $ext.Edge.Id }
+        if ($ext.ContainsKey('Chrome'))  { Set-ADTChromiumForcelistEntry -Browser Chrome -ExtensionId $ext.Chrome.Id }
+        if ($ext.ContainsKey('Firefox')) { Set-ADTFirefoxExtensionSetting -ExtensionId $ext.Firefox.Id -InstallUrl $ext.Firefox.InstallUrl }
+    }
+
+    ##================================================
+    ## MARK: Post-Install
+    ##================================================
+    $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
+}
+
+function Uninstall-ADTDeployment
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    ##================================================
+    ## MARK: Pre-Uninstall
+    ##================================================
+    $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
+
+    Show-ADTInstallationProgress
+
+    ##================================================
+    ## MARK: Uninstall
+    ##================================================
+    $adtSession.InstallPhase = $adtSession.DeploymentType
+
+    ## Remove ONLY our own entries. For Edge/Chrome the browser then auto-uninstalls the extension.
+    foreach ($ext in $script:BrowserExtensions)
+    {
+        Write-ADTLogEntry -Message "Removing browser extension policy for [$($ext.Name)]."
+        if ($ext.ContainsKey('Edge'))    { Remove-ADTChromiumForcelistEntry -Browser Edge   -ExtensionId $ext.Edge.Id }
+        if ($ext.ContainsKey('Chrome'))  { Remove-ADTChromiumForcelistEntry -Browser Chrome -ExtensionId $ext.Chrome.Id }
+        if ($ext.ContainsKey('Firefox')) { Remove-ADTFirefoxExtensionSetting -ExtensionId $ext.Firefox.Id }
+    }
+
+    ##================================================
+    ## MARK: Post-Uninstall
+    ##================================================
+    $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
+}
+
+function Repair-ADTDeployment
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    ##================================================
+    ## MARK: Pre-Repair
+    ##================================================
+    $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
+
+    Show-ADTInstallationProgress
+
+    ##================================================
+    ## MARK: Repair
+    ##================================================
+    $adtSession.InstallPhase = $adtSession.DeploymentType
+
+    ## Idempotent re-apply (same as install). Helpers skip entries that are already present.
+    foreach ($ext in $script:BrowserExtensions)
+    {
+        Write-ADTLogEntry -Message "Re-applying browser extension policy for [$($ext.Name)]."
+        if ($ext.ContainsKey('Edge'))    { Set-ADTChromiumForcelistEntry -Browser Edge   -ExtensionId $ext.Edge.Id }
+        if ($ext.ContainsKey('Chrome'))  { Set-ADTChromiumForcelistEntry -Browser Chrome -ExtensionId $ext.Chrome.Id }
+        if ($ext.ContainsKey('Firefox')) { Set-ADTFirefoxExtensionSetting -ExtensionId $ext.Firefox.Id -InstallUrl $ext.Firefox.InstallUrl }
+    }
+
+    ##================================================
+    ## MARK: Post-Repair
+    ##================================================
+    $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
+}
+
+
+##================================================
+## MARK: Initialization
+##================================================
+
+$ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+Set-StrictMode -Version 1
+
+try
+{
+    if (Test-Path -LiteralPath "$PSScriptRoot\PSAppDeployToolkit\PSAppDeployToolkit.psd1" -PathType Leaf)
+    {
+        Get-ChildItem -LiteralPath "$PSScriptRoot\PSAppDeployToolkit" -Recurse -File | Unblock-File -ErrorAction Ignore
+        Import-Module -FullyQualifiedName @{ ModuleName = "$PSScriptRoot\PSAppDeployToolkit\PSAppDeployToolkit.psd1"; Guid = '8c3c366b-8606-4576-9f2d-4051144f7ca2'; ModuleVersion = '4.1.8' } -Force
+    }
+    else
+    {
+        Import-Module -FullyQualifiedName @{ ModuleName = 'PSAppDeployToolkit'; Guid = '8c3c366b-8606-4576-9f2d-4051144f7ca2'; ModuleVersion = '4.1.8' } -Force
+    }
+
+    $iadtParams = Get-ADTBoundParametersAndDefaultValues -Invocation $MyInvocation
+    $adtSession = Remove-ADTHashtableNullOrEmptyValues -Hashtable $adtSession
+    $adtSession = Open-ADTSession @adtSession @iadtParams -PassThru
+}
+catch
+{
+    $Host.UI.WriteErrorLine((Out-String -InputObject $_ -Width ([System.Int32]::MaxValue)))
+    exit 60008
+}
+
+
+##================================================
+## MARK: Invocation
+##================================================
+
+try
+{
+    Get-ChildItem -LiteralPath $PSScriptRoot -Directory | & {
+        process
+        {
+            if ($_.Name -match 'PSAppDeployToolkit\..+$')
+            {
+                Get-ChildItem -LiteralPath $_.FullName -Recurse -File | Unblock-File -ErrorAction Ignore
+                Import-Module -Name $_.FullName -Force
+            }
+        }
+    }
+
+    & "$($adtSession.DeploymentType)-ADTDeployment"
+    Close-ADTSession
+}
+catch
+{
+    $mainErrorMessage = "An unhandled error within [$($MyInvocation.MyCommand.Name)] has occurred.`n$(Resolve-ADTErrorRecord -ErrorRecord $_)"
+    Write-ADTLogEntry -Message $mainErrorMessage -Severity 3
+    Close-ADTSession -ExitCode 60001
+}
+'@
+
+if (-not $Changelog) { $Changelog = "- 0.1 ($today, $Author): Initial version - force-install browser extensions via policy registry keys." }
+
+$out = $tpl.
+    Replace('__APPVENDOR__', $AppVendor).
+    Replace('__APPNAME__', $AppName).
+    Replace('__APPVERSION__', $AppVersion).
+    Replace('__AUTHOR__', $Author).
+    Replace('__DATE__', $today).
+    Replace('__CHANGELOG__', $Changelog).
+    Replace('__EXTLITERAL__', $extLiteral)
+
+[System.IO.File]::WriteAllText("$pkg\Invoke-AppDeployToolkit.ps1", $out, [System.Text.UTF8Encoding]::new($true))
+
+# 3) Extensions module (the 4 merge/remove helpers). Overwrite the template stub.
+$extModuleDir = Join-Path $pkg 'PSAppDeployToolkit.Extensions'
+if (-not (Test-Path -LiteralPath $extModuleDir)) { New-Item -ItemType Directory -Path $extModuleDir -Force | Out-Null }
+$psd1 = Join-Path $extModuleDir 'PSAppDeployToolkit.Extensions.psd1'
+if (-not (Test-Path -LiteralPath $psd1)) {
+    $manifest = @'
+@{
+    RootModule = 'PSAppDeployToolkit.Extensions.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '3d6a6f6d-7b1e-4a2c-9c8e-0b1d2e3f4a5b'
+    Author = '__AUTHOR__'
+    Description = 'PSAppDeployToolkit extension helpers for browser-extension force-install packages.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @('Set-ADTChromiumForcelistEntry', 'Remove-ADTChromiumForcelistEntry', 'Set-ADTFirefoxExtensionSetting', 'Remove-ADTFirefoxExtensionSetting')
+}
+'@
+    [System.IO.File]::WriteAllText($psd1, $manifest.Replace('__AUTHOR__', $Author), [System.Text.UTF8Encoding]::new($true))
+}
+
+$psm1 = @'
+<#
+.SYNOPSIS
+PSAppDeployToolkit.Extensions - browser-extension force-install helpers (Edge / Chrome / Firefox).
+.DESCRIPTION
+Merge-and-selective-remove helpers for the enterprise policy keys that force-install browser
+extensions. All four helpers leave OTHER packages' entries intact - they key off the extension ID,
+never a fixed registry index. See guide Appendix O.
+#>
+
+$ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+Set-StrictMode -Version 1
+
+# Chromium (Edge/Chrome) ExtensionInstallForcelist policy locations + store update URLs.
+$script:AdtChromiumForcelist = @{
+    Edge   = @{ Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist';  Url = 'https://edge.microsoft.com/extensionwebstorebase/v1/crx' }
+    Chrome = @{ Key = 'HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist';   Url = 'https://clients2.google.com/service/update2/crx' }
+}
+$script:AdtFirefoxPolicyKey = 'HKLM:\SOFTWARE\Policies\Mozilla\Firefox'
+
+function Set-ADTChromiumForcelistEntry
+{
+    <#
+    .SYNOPSIS
+        Adds one extension to the Edge/Chrome ExtensionInstallForcelist policy (merge, idempotent).
+    .DESCRIPTION
+        Computes the next free numeric value name (never hard-codes "1"), so other packages' entries
+        are preserved. If the same extension ID is already present in any entry, it is left as-is.
+    .PARAMETER Browser
+        'Edge' or 'Chrome'.
+    .PARAMETER ExtensionId
+        The store extension ID (32 chars a-p).
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)][ValidateSet('Edge', 'Chrome')][System.String]$Browser,
+        [Parameter(Mandatory)][System.String]$ExtensionId
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                $key = $script:AdtChromiumForcelist[$Browser].Key
+                $entry = "$ExtensionId;$($script:AdtChromiumForcelist[$Browser].Url)"
+                if (!(Test-Path -LiteralPath $key)) { New-Item -Path $key -Force | Out-Null }
+
+                $existing = @()
+                $props = Get-ItemProperty -LiteralPath $key -ErrorAction SilentlyContinue
+                if ($props)
+                {
+                    foreach ($p in $props.PSObject.Properties)
+                    {
+                        if ($p.Name -match '^\d+$') { $existing += [pscustomobject]@{ Index = [int]$p.Name; Value = [string]$p.Value } }
+                    }
+                }
+
+                if (@($existing | Where-Object { $_.Value -like "$ExtensionId;*" }).Count -gt 0)
+                {
+                    Write-ADTLogEntry -Message "$Browser forcelist already manages [$ExtensionId]; nothing to do."
+                    return
+                }
+
+                $next = 1
+                if ($existing.Count -gt 0) { $next = ([int]($existing | Measure-Object -Property Index -Maximum).Maximum) + 1 }
+                New-ItemProperty -LiteralPath $key -Name "$next" -Value $entry -PropertyType String -Force | Out-Null
+                Write-ADTLogEntry -Message "$Browser forcelist: added [$entry] at index $next."
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+function Remove-ADTChromiumForcelistEntry
+{
+    <#
+    .SYNOPSIS
+        Removes ONLY this extension's entry from the Edge/Chrome ExtensionInstallForcelist policy.
+    .DESCRIPTION
+        Finds the value whose data matches "<id>;..." and deletes only that value name. Other packages'
+        entries are untouched. Removing the entry makes the browser auto-uninstall the extension.
+    .PARAMETER Browser
+        'Edge' or 'Chrome'.
+    .PARAMETER ExtensionId
+        The store extension ID to remove.
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)][ValidateSet('Edge', 'Chrome')][System.String]$Browser,
+        [Parameter(Mandatory)][System.String]$ExtensionId
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                $key = $script:AdtChromiumForcelist[$Browser].Key
+                if (!(Test-Path -LiteralPath $key)) { return }
+                $props = Get-ItemProperty -LiteralPath $key -ErrorAction SilentlyContinue
+                if (!$props) { return }
+                foreach ($p in $props.PSObject.Properties)
+                {
+                    if (($p.Name -match '^\d+$') -and ([string]$p.Value -like "$ExtensionId;*"))
+                    {
+                        Remove-ItemProperty -LiteralPath $key -Name $p.Name -Force
+                        Write-ADTLogEntry -Message "$Browser forcelist: removed [$ExtensionId] (was index $($p.Name))."
+                    }
+                }
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+function Set-ADTFirefoxExtensionSetting
+{
+    <#
+    .SYNOPSIS
+        Adds one extension to the Firefox ExtensionSettings policy as force_installed (merge).
+    .DESCRIPTION
+        Reads the existing ExtensionSettings REG_MULTI_SZ JSON, merges this extension, and writes it
+        back as REG_MULTI_SZ. CRITICAL: the value MUST be REG_MULTI_SZ - current Firefox silently
+        ignores a single-line REG_SZ (Mozilla bug 1750233).
+    .PARAMETER ExtensionId
+        The Firefox extension ID (e.g. name@domain or a GUID).
+    .PARAMETER InstallUrl
+        The AMO install_url (.xpi) the extension is fetched from.
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)][System.String]$ExtensionId,
+        [Parameter(Mandatory)][System.String]$InstallUrl
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                $key = $script:AdtFirefoxPolicyKey
+                if (!(Test-Path -LiteralPath $key)) { New-Item -Path $key -Force | Out-Null }
+
+                $obj = $null
+                $raw = (Get-ItemProperty -LiteralPath $key -Name 'ExtensionSettings' -ErrorAction SilentlyContinue).'ExtensionSettings'
+                if ($raw)
+                {
+                    $joined = ($raw -join '')
+                    try { $obj = $joined | ConvertFrom-Json -ErrorAction Stop } catch { $obj = $null }
+                }
+                if (!$obj) { $obj = [pscustomobject]@{} }
+
+                $setting = [pscustomobject]@{ installation_mode = 'force_installed'; install_url = $InstallUrl }
+                $obj | Add-Member -NotePropertyName $ExtensionId -NotePropertyValue $setting -Force
+
+                $json = $obj | ConvertTo-Json -Depth 6 -Compress
+                # Write as REG_MULTI_SZ (MultiString) - a single-element array is one line of JSON.
+                New-ItemProperty -LiteralPath $key -Name 'ExtensionSettings' -Value @($json) -PropertyType MultiString -Force | Out-Null
+                Write-ADTLogEntry -Message "Firefox ExtensionSettings: ensured [$ExtensionId] force_installed."
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+function Remove-ADTFirefoxExtensionSetting
+{
+    <#
+    .SYNOPSIS
+        Removes ONLY this extension's key from the Firefox ExtensionSettings policy JSON.
+    .DESCRIPTION
+        Parses the ExtensionSettings JSON, removes this extension ID, and writes the rest back as
+        REG_MULTI_SZ. If it was the last entry, the value is deleted. Other extensions are preserved.
+    .PARAMETER ExtensionId
+        The Firefox extension ID to remove.
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)][System.String]$ExtensionId
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                $key = $script:AdtFirefoxPolicyKey
+                if (!(Test-Path -LiteralPath $key)) { return }
+                $raw = (Get-ItemProperty -LiteralPath $key -Name 'ExtensionSettings' -ErrorAction SilentlyContinue).'ExtensionSettings'
+                if (!$raw) { return }
+                $joined = ($raw -join '')
+                try { $obj = $joined | ConvertFrom-Json -ErrorAction Stop } catch { return }
+                if (!$obj.PSObject.Properties[$ExtensionId]) { return }
+
+                $obj.PSObject.Properties.Remove($ExtensionId)
+                # Test emptiness via the serialized JSON, NOT PSObject.Properties.Count: after removing the
+                # last note property, PSCustomObject reports a phantom empty-named property (count 1), but
+                # ConvertTo-Json correctly yields '{}'.
+                $json = $obj | ConvertTo-Json -Depth 6 -Compress
+                if ([string]::IsNullOrWhiteSpace($json) -or $json -eq '{}')
+                {
+                    Remove-ItemProperty -LiteralPath $key -Name 'ExtensionSettings' -Force -ErrorAction SilentlyContinue
+                    Write-ADTLogEntry -Message "Firefox ExtensionSettings: removed last entry [$ExtensionId]; deleted value."
+                }
+                else
+                {
+                    New-ItemProperty -LiteralPath $key -Name 'ExtensionSettings' -Value @($json) -PropertyType MultiString -Force | Out-Null
+                    Write-ADTLogEntry -Message "Firefox ExtensionSettings: removed [$ExtensionId]."
+                }
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+Write-ADTLogEntry -Message "Module [$($MyInvocation.MyCommand.ScriptBlock.Module.Name)] imported successfully." -ScriptSection Initialization
+'@
+[System.IO.File]::WriteAllText((Join-Path $extModuleDir 'PSAppDeployToolkit.Extensions.psm1'), $psm1, [System.Text.UTF8Encoding]::new($true))
+
+# 4) Detection script - verifies the policy is SET (not whether the browser loaded the extension).
+$detect = @'
+# Detect-__NAME__.ps1 - Intune detection for __APPNAME__ (__APPVERSION__).
+# Honest model: checks that the force-install POLICY is present in the registry. It does NOT verify
+# that each browser/profile has actually downloaded the extension (that is online + per-user).
+# Contract: write to stdout + exit 0 when all managed policies are present; otherwise no output + exit 0.
+
+$exts = __EXTLITERAL__
+
+$chromium = @{
+    Edge   = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist'
+    Chrome = 'HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist'
+}
+$firefoxKey = 'HKLM:\SOFTWARE\Policies\Mozilla\Firefox'
+
+function Test-ChromiumForce([string]$Browser, [string]$Id)
+{
+    $key = $chromium[$Browser]
+    if (-not (Test-Path -LiteralPath $key)) { return $false }
+    $props = Get-ItemProperty -LiteralPath $key -ErrorAction SilentlyContinue
+    if (-not $props) { return $false }
+    foreach ($p in $props.PSObject.Properties)
+    {
+        if (($p.Name -match '^\d+$') -and ([string]$p.Value -like "$Id;*")) { return $true }
+    }
+    return $false
+}
+
+function Test-FirefoxForce([string]$Id)
+{
+    if (-not (Test-Path -LiteralPath $firefoxKey)) { return $false }
+    $raw = (Get-ItemProperty -LiteralPath $firefoxKey -Name 'ExtensionSettings' -ErrorAction SilentlyContinue).'ExtensionSettings'
+    if (-not $raw) { return $false }
+    try { $obj = (($raw -join '') | ConvertFrom-Json -ErrorAction Stop) } catch { return $false }
+    $prop = $obj.PSObject.Properties[$Id]
+    if (-not $prop) { return $false }
+    return ($prop.Value.installation_mode -eq 'force_installed')
+}
+
+$found = @()
+$allOk = $true
+foreach ($ext in $exts)
+{
+    if ($ext.ContainsKey('Edge'))    { if (Test-ChromiumForce 'Edge'   $ext.Edge.Id)   { $found += "Edge:$($ext.Edge.Id)" }   else { $allOk = $false } }
+    if ($ext.ContainsKey('Chrome'))  { if (Test-ChromiumForce 'Chrome' $ext.Chrome.Id) { $found += "Chrome:$($ext.Chrome.Id)" } else { $allOk = $false } }
+    if ($ext.ContainsKey('Firefox')) { if (Test-FirefoxForce $ext.Firefox.Id)          { $found += "Firefox:$($ext.Firefox.Id)" } else { $allOk = $false } }
+}
+
+if ($allOk -and $found.Count -gt 0)
+{
+    Write-Output ("Detected browser-extension policies: " + ($found -join ', '))
+    exit 0
+}
+exit 0
+'@
+$detect = $detect.
+    Replace('__NAME__', $Name).
+    Replace('__APPNAME__', $AppName).
+    Replace('__APPVERSION__', $AppVersion).
+    Replace('__EXTLITERAL__', $extLiteral)
+[System.IO.File]::WriteAllText("$pkg\Detect-$Name.ps1", $detect, [System.Text.UTF8Encoding]::new($true))
+
+Write-Output "PACKAGE_OK: $pkg"
+Write-Output "Next: Phase 5 pre-flight (scripts/Invoke-PsadtPreflight.ps1 -PackagePath '$pkg') -> Phase 7 package -> Phase 8 dossier."


### PR DESCRIPTION
## Summary
Adds a new **opt-in package type** to the skill: force-install browser extensions for **Edge / Chrome / Firefox** via enterprise **policy registry keys** (policy-only — no vendor installer, `Files\` empty, ESP-safe, no reboot). Each browser then pulls the extension from its own store.

## What's included
- **`scripts/New-BrowserExtensionPackage.ps1`** — one-call generator producing the launcher (data model + 3 hooks), the Extensions module (4 merge/remove helpers) and the detection script. **Multiple extensions per package** across the three browsers.
- **Guide Appendix O** — model, Phase-2 store-availability research + per-store IDs (Chrome/Edge 32-char `a-p`, Firefox `id@domain` + AMO slug), verbatim registry reference, helpers, hooks, the honest detection model, dossier additions, anti-patterns.
- **SKILL.md** control-plane — Gate-1 package-type option, Phase-2 research note, three anti-patterns, reference-lookup line.
- README project tree + CHANGELOG (0.14.0).

## Correctness highlights
- **Coexistence:** Chromium helper computes the **next free `ExtensionInstallForcelist` index** (never hard-codes `1`), dedupes by extension ID, removes only its own entry. Firefox merges into the single `ExtensionSettings` JSON keyed by ID.
- **Firefox `REG_MULTI_SZ` trap:** written as `REG_MULTI_SZ`; a single-line `REG_SZ` is silently ignored by current Firefox (Mozilla bug 1750233).

## Verification
- Generated package passes the Phase-5 pre-flight **GREEN** (3 hooks + all 4 helpers wired).
- All four helpers validated against a scratch registry hive: next-free index, idempotent add, selective remove, `REG_MULTI_SZ` merge incl. remove-last cleanup (a real bug here was found and fixed — emptiness now tested via `ConvertTo-Json == {}`, not `PSObject.Properties.Count`).
- Generator is 7-bit ASCII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
