### PR TITLE
feat(skill): windows-feature packages (optional features + capabilities/FoD) (0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.15.0 — 2026-06-15 — Windows-feature packages (optional features + capabilities / FoD)
+
+### Added
+- **`scripts/New-WindowsFeaturePackage.ps1`** — one-call generator for a new opt-in package type: enable
+  **Windows Optional Features** (`Enable-WindowsOptionalFeature`, e.g. NetFx3, Hyper-V, WSL, TelnetClient) and
+  **Capabilities / Features on Demand** (`Add-WindowsCapability`, e.g. RSAT.*, OpenSSH) — both in one typed list,
+  multiple per package. Feature-only (no vendor installer). Writes the launcher (data model + 3 hooks), the
+  Extensions module (enable/disable dispatch + WU-FoD access toggle) and the detection script.
+- **Guide Appendix P** — model, Phase-2 name/reboot/source research, cmdlet+state reference, generator usage,
+  helpers, hooks (3010), detection + Intune wiring, content source (bundled SxS vs Windows Update / WSUS-bypass),
+  dossier additions, anti-patterns.
+- SKILL.md control-plane: Gate-1 package-type option, Phase-2 research note, anti-patterns, reference-lookup
+  line for Appendix P.
+
+### Notes
+- **Uninstall reverts** (`Disable-WindowsOptionalFeature` / `Remove-WindowsCapability`); Repair re-enables
+  (idempotent). Enable/disable helpers skip features already in the target state.
+- **Reboot:** features that report `RestartNeeded` surface **3010** via `$adtSession.SetExitCode(3010)`;
+  `-NoRestart` prevents DISM from rebooting mid-install. Detection treats `EnablePending` as not-yet-done.
+- **Content source:** bundled `Files\<Source>` via `-Source -LimitAccess` (offline), else Windows Update with a
+  **temporary** WSUS bypass (`RepairContentServerSource=2`, `UseWUServer=0`) that records and **restores** the
+  exact prior state — reuses the proven pattern from the existing `RSAT-1.0.0` package.
+- Verified: generated package passes the Phase-5 pre-flight **GREEN**; enable/disable dispatch + idempotency +
+  clean boolean returns and the WU-FoD save/restore (incl. remove-value-that-didn't-exist) validated against an
+  in-memory registry sim; generator is 7-bit ASCII-clean.
+
 ## 0.14.0 — 2026-06-15 — Browser-extension force-install packages (Edge / Chrome / Firefox)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,12 +168,13 @@ psadt-deploy/
 │  ├─ New-PsadtReport.ps1           HTML package report (Phase 8, always)
 │  ├─ New-MsiPackage.ps1            reusable MSI package generator (opt-in)
 │  ├─ New-BrowserExtensionPackage.ps1  browser-extension force-install generator (opt-in)
+│  ├─ New-WindowsFeaturePackage.ps1  windows optional-feature / capability generator (opt-in)
 │  ├─ New-PsadtEntraApp.ps1         Entra app bootstrap (WAM)
 │  ├─ Get-GraphToken.ps1            app-only Graph token (cert/DPAPI)
 │  ├─ _GraphCommon.ps1              shared Graph helpers (3 upload scripts)
 │  ├─ Invoke-IntuneWin32Upload.ps1  direct Intune upload (Phase 9)
 │  └─ Invoke-IntuneAppAssignment.ps1 opt-in Entra group assignment (Phase 10)
-├─ references/   guide (App. A-O) + Report-Template.html + app-registration.md
+├─ references/   guide (App. A-P) + Report-Template.html + app-registration.md
 ├─ tests/        Pester suite for the scripts
 ├─ tools/        (gitignored)  IntuneWinAppUtil.exe + WinGet module
 ├─ config.json   (gitignored)  machine-local settings (intune.* block)

--- a/SKILL.md
+++ b/SKILL.md
@@ -53,7 +53,8 @@ researched defaults; recommended option first.
    auto-select WinGet even if a package exists. If WinGet is chosen, follow guide Appendix I. **Package type**
    is part of this gate when ambiguous: native installer (default) · WinGet (opt-in, App. I) · script-only
    fix/remediation (App. K) · **browser-extension force-install** (Edge/Chrome/Firefox via policy keys, App. O,
-   built by `scripts/New-BrowserExtensionPackage.ps1`).
+   built by `scripts/New-BrowserExtensionPackage.ps1`) · **windows-features** (Enable-WindowsOptionalFeature /
+   Add-WindowsCapability, App. P, built by `scripts/New-WindowsFeaturePackage.ps1`).
 2. **Deployment semantics** - target audience (Required / Available / both, + AAD groups), uninstall "what
    goes vs. what stays", repair strategy, reboot behaviour (never / 3010 / 1641). Pre-select defaults from
    the installer type. Group assignment is **opt-in**: only when the user wants it here do you create/assign
@@ -162,7 +163,9 @@ type: switch, expected exit codes, log path, known leftovers. **Consult guide Ap
 + silent switches) BEFORE web-searching switches**; for a script-only fix/remediation/debloat package (no vendor
 installer) follow guide Appendix K instead of the normal installer flow. For a **browser-extension** package the
 research is store-availability + per-store IDs (Chrome/Edge 32-char `a-p`, Firefox `id@domain` + AMO slug), not
-silent switches - guide Appendix O.2. On a newer PSADT release, ALWAYS diff the
+silent switches - guide Appendix O.2. For a **windows-features** package the research is the exact
+`FeatureName`/capability `Name` (via `Get-WindowsOptionalFeature -Online` / `Get-WindowsCapability -Online -Name`)
+plus reboot + content-source need (bundled SxS vs Windows Update) - guide Appendix P.2. On a newer PSADT release, ALWAYS diff the
 release notes for renamed/deprecated/changed commands before building - never adopt a version by number alone;
 verify the actually-used cmdlets with `Get-Command -Module PSAppDeployToolkit` (and `Get-Help <cmdlet>
 -Parameter *` for changed params). If divergent, recommend `Update-Module PSAppDeployToolkit -Force` before
@@ -306,6 +309,9 @@ Full symptom/HRESULT catalogue: guide Appendix A.
   ignored); clobbering the whole forcelist key / hard-coding index `1` instead of merging at the next free index
   (wipes other extension packages); a detection that claims the extension is "installed" rather than that the
   policy is set.
+- Windows features (App. P): enabling WITHOUT `-NoRestart` (DISM reboots mid-install instead of returning 3010);
+  forgetting the temporary WSUS bypass on managed devices (`0x800f0950` content-not-found) or not restoring it;
+  detection run as 32-bit (DISM needs 64-bit); treating `EnablePending` as installed.
 
 ## Reference lookup
 
@@ -318,4 +324,6 @@ learned · H direct Graph upload · **I WinGet packaging** · **J app-logo acqui
 **N certificate store deployment (driver-trust / TrustedPublisher; RootCATrustedCertificates CSP OMA-URI;
 `New-IntuneTrustedCertPolicy.ps1`)** ·
 **O browser-extension force-install (opt-in: Edge/Chrome/Firefox policy keys, Firefox `REG_MULTI_SZ` trap,
-merge/selective-remove; `New-BrowserExtensionPackage.ps1`)**.
+merge/selective-remove; `New-BrowserExtensionPackage.ps1`)** ·
+**P windows-features (opt-in: Enable-WindowsOptionalFeature + Add-WindowsCapability, 3010 reboot, WU/WSUS-bypass
+content source, EnablePending detection; `New-WindowsFeaturePackage.ps1`)**.

--- a/references/PSADTv4-Deployment-Guide.md
+++ b/references/PSADTv4-Deployment-Guide.md
@@ -1873,3 +1873,118 @@ Reuse the standard `$meta` fields - no new template tokens:
 - Hard-coding forcelist index `1` - collides with other extension packages.
 - Detection that asserts the extension is installed in the profile (it can only assert the policy is set).
 - Self-hosted CRX/XPI dressed up as "store force-install" - different mechanism, out of scope here.
+
+---
+
+## Appendix P: Windows-feature packages (optional features + capabilities, opt-in)
+
+Enable **additional Windows features** as an Intune Win32 app. Two mechanisms, one generator:
+- **Optional Features** (DISM): `Enable-WindowsOptionalFeature` - e.g. `NetFx3`, `Microsoft-Hyper-V-All`,
+  `Microsoft-Windows-Subsystem-Linux`, `TelnetClient`, `TFTP`, `Containers-DisposableClientVM` (Windows Sandbox).
+- **Capabilities / Features on Demand (FoD)**: `Add-WindowsCapability` - e.g. `Rsat.*~~~~0.0.1.0`,
+  `OpenSSH.Client~~~~0.0.1.0`.
+
+Feature-only package: no vendor installer; `Files\` is empty unless you bundle an offline source. Built in one
+call by **`scripts/New-WindowsFeaturePackage.ps1`** (launcher + Extensions helpers + detection). Opt-in
+(Gate-1 package-type choice). Live example already in the repo: `Output\RSAT-1.0.0`.
+
+### P.1 Model
+
+| | |
+|---|---|
+| Source | Bundled offline `-Source` if present, else **Windows Update** (with a temporary WSUS bypass, P.8). |
+| Reboot | Many optional features need a reboot -> `-NoRestart`, surface **3010** (P.6). So **NOT always ESP-safe** - if blocking during ESP, expect the OOBE reboot. |
+| Deployment types | Install = enable, Uninstall = **revert** (disable/remove), Repair = re-enable (idempotent). |
+| Coexistence | Feature state is global + idempotent (no shared-key merge like the forcelist). The risk is Uninstall: disabling a feature another product needs - scope the assignment. |
+| Detection | Each feature in its target state: OptionalFeature -> `Enabled`, Capability -> `Installed` (P.7). |
+
+### P.2 Phase-2 research (replaces the silent-switch research)
+
+Capture the **exact** name and whether content/reboot is needed:
+```powershell
+Get-WindowsOptionalFeature -Online | Where-Object FeatureName -like '*<term>*' | Select FeatureName, State
+Get-WindowsCapability -Online -Name '*<term>*' | Select Name, State            # FoD names end ~~~~0.0.1.0
+```
+Note per feature: exact `FeatureName`/capability `Name`, reboot expectation, and whether an offline source is
+required (NetFx3 on locked-down/no-WU clients) or WU is reachable. Capability names are version-suffixed
+(`Rsat.Dns.Tools~~~~0.0.1.0`) - copy them verbatim.
+
+### P.3 Cmdlet + state reference
+
+| Type | Enable | Disable / Remove | Detect cmdlet | Target state |
+|---|---|---|---|---|
+| OptionalFeature | `Enable-WindowsOptionalFeature -Online -FeatureName <n> -All -NoRestart [-Source <p> -LimitAccess]` | `Disable-WindowsOptionalFeature -Online -FeatureName <n> -NoRestart` | `Get-WindowsOptionalFeature -Online -FeatureName <n>` | `Enabled` |
+| Capability | `Add-WindowsCapability -Online -Name <n> [-Source <p> -LimitAccess]` | `Remove-WindowsCapability -Online -Name <n>` | `Get-WindowsCapability -Online -Name <n>` | `Installed` |
+
+`-All` pulls in parent/dependency features. The enable cmdlets return an object with `.RestartNeeded`.
+`EnablePending` = enabled but awaiting reboot (detection treats it as not-yet-done, P.7).
+
+### P.4 Generate the package (one call, in-process)
+
+`-Features` is an array of hashtables, so call **in-process** (not `pwsh -File`, which stringifies the array):
+```powershell
+$feats = @(
+    @{ Type='OptionalFeature'; Name='NetFx3'; Source='sxs' }   # Source optional: a relative path under Files\
+    @{ Type='OptionalFeature'; Name='TelnetClient' }
+    @{ Type='Capability';      Name='Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0' }
+)
+& scripts/New-WindowsFeaturePackage.ps1 -Name 'WinFeatures-Admin' `
+    -AppName 'Windows Features: RSAT + .NET 3.5' -Features $feats
+```
+The model lands as `$script:WindowsFeatures` at the top of `Invoke-AppDeployToolkit.ps1` (single source of truth
+for the three hooks AND the detection script). For an offline source, drop the SxS cabs under `Files\<Source>`
+(e.g. `Files\sxs` from the ISO `sources\sxs`).
+
+### P.5 Extensions helpers
+
+Written into `PSAppDeployToolkit.Extensions.psm1`:
+- `Enable-ADTWindowsFeatureItem -Type -Name [-SourcePath]` - dispatches OptionalFeature vs Capability;
+  idempotent (skips if already `Enabled`/`Installed`); uses `-Source -LimitAccess` when `SourcePath` exists,
+  else pulls from WU; **returns $true if a restart is needed**.
+- `Disable-ADTWindowsFeatureItem -Type -Name` - disable/remove, idempotent; returns restart-needed.
+- `Set-ADTWindowsUpdateFodAccess` / `Restore-ADTWindowsUpdateFodAccess` - temporary WSUS bypass
+  (`RepairContentServerSource=2`, `UseWUServer=0`, restart `wuauserv`) that **records the exact prior state**
+  and restores it (re-set prior value, or remove the value if it did not exist before).
+
+### P.6 Hooks + reboot
+
+Install wraps the enable loop in `try { ... } finally { Restore-ADTWindowsUpdateFodAccess }` (the bypass is set
+only when at least one feature lacks a bundled source). If any feature reports `RestartNeeded`, the hook calls
+**`$adtSession.SetExitCode(3010)`** - the launcher's trailing `Close-ADTSession` then returns 3010 and Intune
+prompts the reboot. `AppRebootExitCodes=@(1641,3010)`. Uninstall reverts; Repair re-enables. Generated for you.
+
+### P.7 Detection + Intune wiring
+
+`Detect-<Name>.ps1` embeds the model and checks every feature is `Enabled`/`Installed`. Contract: stdout +
+`exit 0` when ALL present; no output + `exit 0` otherwise. **`EnablePending` counts as not-yet-detected** -
+honest: after the 3010 reboot the state flips to `Enabled`/`Installed` and detection passes. Intune: Install
+behavior **System**; `-DeployMode Silent`; detection = **script rule, Run as 32-bit = No** (DISM cmdlets need
+64-bit). Pre-flight (Phase 5) passes unchanged.
+
+### P.8 Content source (bundled vs Windows Update)
+
+- **Bundled (offline):** put the SxS cabs under `Files\<Source>`; the helper uses `-Source <path> -LimitAccess`
+  (no WU contact). Best for NetFx3 on locked-down clients; the package grows and must match the Windows build.
+- **Windows Update (default when no source):** WSUS-bound devices cannot fetch FoD/optional-feature content
+  unless `RepairContentServerSource=2` (`...\Policies\Servicing`) and `UseWUServer=0` (`...\WindowsUpdate\AU`)
+  are set. The helper sets these **temporarily** and restores them in `finally`. Symptom when missing:
+  `0x800f0950` / `0x800f081f` "source files could not be found".
+
+### P.9 Dossier additions
+
+Reuse the standard `$meta` fields - no new template tokens:
+- `DescMdDe/En`: list the features (type + name) and whether a reboot is expected.
+- `RuleFormat` / detection note: "feature state (Enabled/Installed); reboot may be required before detection
+  succeeds."
+- Requirements: note the content source (bundled vs Windows Update / network needed).
+- Reboot behaviour: 3010 soft reboot when a feature requests it.
+
+### P.10 Anti-patterns
+
+- Writing the detection to require `Enabled`/`Installed` but enabling **without `-NoRestart`** - the DISM call
+  reboots the device mid-install instead of returning 3010.
+- Forgetting the WSUS bypass on managed devices -> `0x800f0950` (content not found). And: setting the bypass but
+  not restoring it (leaves the device pulling FoD directly from WU permanently).
+- Detection run as 32-bit (DISM cmdlets unavailable / wrong view) - must be 64-bit.
+- Disabling a **shared** feature on uninstall and breaking other software - scope the assignment, document it.
+- Treating `EnablePending` as installed (it isn't yet) - rely on the 3010 reboot, then re-detect.

--- a/scripts/New-WindowsFeaturePackage.ps1
+++ b/scripts/New-WindowsFeaturePackage.ps1
@@ -1,0 +1,677 @@
+#Requires -Modules PSAppDeployToolkit
+<#
+    New-WindowsFeaturePackage.ps1 - reusable PSADT v4.1.8 generator for Windows-feature packages.
+
+    Enables additional Windows features as an Intune Win32 app, covering BOTH mechanisms:
+      - Optional Features (DISM): Enable-WindowsOptionalFeature  (e.g. NetFx3, Microsoft-Hyper-V-All,
+        Microsoft-Windows-Subsystem-Linux, TelnetClient)
+      - Capabilities / Features on Demand: Add-WindowsCapability  (e.g. Rsat.*~~~~0.0.1.0, OpenSSH.Client~~~~0.0.1.0)
+
+    Feature-only package: no vendor installer. `Files\` is empty unless you bundle an offline source (e.g. the
+    NetFx3 SxS cabs from a Windows ISO under Files\sxs). Install enables, Uninstall reverts (disable/remove),
+    Repair re-applies. Content comes from a bundled -Source when present, otherwise from Windows Update with a
+    temporary WSUS bypass that is restored afterwards.
+
+    English/ASCII only in all generated script content (encoding cleanliness). See guide Appendix P.
+
+    .PARAMETER Features
+    Array of hashtables, one per feature:
+        @{ Type='OptionalFeature'; Name='NetFx3'; Source='sxs' }   # Source optional: a relative path under Files\
+        @{ Type='OptionalFeature'; Name='TelnetClient' }
+        @{ Type='Capability';      Name='Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0' }
+    Type must be 'OptionalFeature' or 'Capability'. Source is optional (offline content); without it the feature
+    is pulled from Windows Update.
+
+    .EXAMPLE
+    $feats = @(
+        @{ Type='OptionalFeature'; Name='NetFx3' }
+        @{ Type='Capability';      Name='Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0' }
+    )
+    & scripts/New-WindowsFeaturePackage.ps1 -Name 'WinFeatures-NetFx3-RSATAD' `
+        -AppName 'Windows Features: .NET 3.5 + RSAT AD' -Features $feats
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Name,                 # package folder + scaffold name (path-safe)
+    [Parameter(Mandatory)][string]$AppName,              # display name in $adtSession
+    [string]$AppVersion = '1.0',
+    [Parameter(Mandatory)][hashtable[]]$Features,        # see .PARAMETER Features
+    [string]$AppVendor = 'Windows Features',
+    [string]$Author,
+    [string]$PackageRoot,
+    [string]$Changelog = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Import-Module PSAppDeployToolkit -Force
+
+if (-not $PackageRoot) { $PackageRoot = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1')).Config.paths.packageRoot }
+if (-not $Author) {
+    $cfg = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1')).Config
+    if ($cfg) { $Author = "$($cfg.author.person), $($cfg.author.company)" }
+}
+$today = (Get-Item $PSCommandPath).LastWriteTime.ToString('yyyy-MM-dd')  # avoid Get-Date (sandbox)
+
+# --- Validate + normalize the feature list --------------------------------------------------------
+$norm = foreach ($f in $Features) {
+    $type = [string]$f.Type
+    if ($type -ne 'OptionalFeature' -and $type -ne 'Capability') {
+        throw "Feature '$($f.Name)': Type must be 'OptionalFeature' or 'Capability' (got '$type')."
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$f.Name)) { throw "Each feature needs a Name." }
+    $f
+}
+
+# --- Render the shared $WindowsFeatures literal (used by launcher AND detection) ------------------
+function ConvertTo-Literal([string]$s) { "'" + ($s -replace "'", "''") + "'" }
+$lines = foreach ($f in $norm) {
+    $parts = @("Type = $(ConvertTo-Literal ([string]$f.Type))", "Name = $(ConvertTo-Literal ([string]$f.Name))")
+    if (-not [string]::IsNullOrWhiteSpace([string]$f.Source)) { $parts += "Source = $(ConvertTo-Literal ([string]$f.Source))" }
+    "    @{ " + ($parts -join '; ') + " }"
+}
+$featLiteral = "@(`r`n" + ($lines -join "`r`n") + "`r`n)"
+
+# 1) Scaffold
+$pkg = Join-Path $PackageRoot $Name
+if (Test-Path $pkg) { Remove-Item $pkg -Recurse -Force }
+New-ADTTemplate -Destination $PackageRoot -Name $Name -Force | Out-Null
+
+# 2) Launcher
+$tpl = @'
+<#
+.SYNOPSIS
+PSAppDeployToolkit - Enables / reverts Windows features for __APPNAME__.
+.DESCRIPTION
+Feature-only package (no vendor installer): enables Windows Optional Features (Enable-WindowsOptionalFeature)
+and/or Capabilities/FoD (Add-WindowsCapability). Three deployment types (Install / Uninstall / Repair) for
+Intune Win32 (PSADT v4.1.8). Custom helpers live in PSAppDeployToolkit.Extensions.
+.NOTES
+Changelog:
+__CHANGELOG__
+.LINK
+https://psappdeploytoolkit.com
+#>
+
+[CmdletBinding()]
+param
+(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Install', 'Uninstall', 'Repair')]
+    [System.String]$DeploymentType,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Auto', 'Interactive', 'NonInteractive', 'Silent')]
+    [System.String]$DeployMode,
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.SwitchParameter]$SuppressRebootPassThru,
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.SwitchParameter]$TerminalServerMode,
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.SwitchParameter]$DisableLogging
+)
+
+
+##================================================
+## MARK: Variables
+##================================================
+
+$adtSession = @{
+    AppVendor = '__APPVENDOR__'
+    AppName = '__APPNAME__'
+    AppVersion = '__APPVERSION__'
+    AppArch = 'x64'
+    AppLang = 'EN'
+    AppRevision = '01'
+    AppSuccessExitCodes = @(0, 1707)
+    AppRebootExitCodes = @(1641, 3010)
+    AppProcessesToClose = @()
+    AppScriptVersion = '0.1'
+    AppScriptDate = '__DATE__'
+    AppScriptAuthor = '__AUTHOR__'
+    RequireAdmin = $true
+
+    InstallName = ''
+    InstallTitle = ''
+
+    DeployAppScriptFriendlyName = $MyInvocation.MyCommand.Name
+    DeployAppScriptParameters = $PSBoundParameters
+    DeployAppScriptVersion = '4.1.8'
+}
+
+## Single source of truth for all three hooks + the detection script: the managed Windows features.
+## Each entry: Type = 'OptionalFeature' (Enable/Disable-WindowsOptionalFeature) or 'Capability'
+## (Add/Remove-WindowsCapability); Name = exact feature/capability name; optional Source = a relative path
+## under Files\ holding offline content (e.g. NetFx3 SxS cabs). Without Source the feature is pulled from
+## Windows Update (the install hook temporarily enables WU FoD access and restores it afterwards).
+$script:WindowsFeatures = __FEATLITERAL__
+
+function Install-ADTDeployment
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    ##================================================
+    ## MARK: Pre-Install
+    ##================================================
+    $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
+
+    Show-ADTInstallationProgress
+
+    ##================================================
+    ## MARK: Install
+    ##================================================
+    $adtSession.InstallPhase = $adtSession.DeploymentType
+
+    ## If any feature has no bundled source, content must come from Windows Update - temporarily allow that on
+    ## WSUS-managed devices, and always restore the prior state in the finally block.
+    $restartNeeded = $false
+    $wuNeeded = @($script:WindowsFeatures | Where-Object { [string]::IsNullOrWhiteSpace($_.Source) }).Count -gt 0
+    if ($wuNeeded) { Set-ADTWindowsUpdateFodAccess }
+    try
+    {
+        foreach ($f in $script:WindowsFeatures)
+        {
+            $src = ''
+            if (-not [string]::IsNullOrWhiteSpace($f.Source)) { $src = Join-Path -Path $adtSession.DirFiles -ChildPath $f.Source }
+            if (Enable-ADTWindowsFeatureItem -Type $f.Type -Name $f.Name -SourcePath $src) { $restartNeeded = $true }
+        }
+    }
+    finally
+    {
+        if ($wuNeeded) { Restore-ADTWindowsUpdateFodAccess }
+    }
+
+    ##================================================
+    ## MARK: Post-Install
+    ##================================================
+    $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
+
+    if ($restartNeeded)
+    {
+        Write-ADTLogEntry -Message 'One or more features require a restart; returning 3010 (soft reboot).'
+        $adtSession.SetExitCode(3010)
+    }
+}
+
+function Uninstall-ADTDeployment
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    ##================================================
+    ## MARK: Pre-Uninstall
+    ##================================================
+    $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
+
+    Show-ADTInstallationProgress
+
+    ##================================================
+    ## MARK: Uninstall
+    ##================================================
+    $adtSession.InstallPhase = $adtSession.DeploymentType
+
+    ## Revert: disable optional features / remove capabilities. NOTE: a feature shared with other software is
+    ## disabled here too - scope the assignment accordingly.
+    $restartNeeded = $false
+    foreach ($f in $script:WindowsFeatures)
+    {
+        if (Disable-ADTWindowsFeatureItem -Type $f.Type -Name $f.Name) { $restartNeeded = $true }
+    }
+
+    ##================================================
+    ## MARK: Post-Uninstall
+    ##================================================
+    $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
+
+    if ($restartNeeded)
+    {
+        Write-ADTLogEntry -Message 'One or more features require a restart to finish removal; returning 3010.'
+        $adtSession.SetExitCode(3010)
+    }
+}
+
+function Repair-ADTDeployment
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    ##================================================
+    ## MARK: Pre-Repair
+    ##================================================
+    $adtSession.InstallPhase = "Pre-$($adtSession.DeploymentType)"
+
+    Show-ADTInstallationProgress
+
+    ##================================================
+    ## MARK: Repair
+    ##================================================
+    $adtSession.InstallPhase = $adtSession.DeploymentType
+
+    ## Idempotent re-enable (same as install). Helpers skip features already in the target state.
+    $restartNeeded = $false
+    $wuNeeded = @($script:WindowsFeatures | Where-Object { [string]::IsNullOrWhiteSpace($_.Source) }).Count -gt 0
+    if ($wuNeeded) { Set-ADTWindowsUpdateFodAccess }
+    try
+    {
+        foreach ($f in $script:WindowsFeatures)
+        {
+            $src = ''
+            if (-not [string]::IsNullOrWhiteSpace($f.Source)) { $src = Join-Path -Path $adtSession.DirFiles -ChildPath $f.Source }
+            if (Enable-ADTWindowsFeatureItem -Type $f.Type -Name $f.Name -SourcePath $src) { $restartNeeded = $true }
+        }
+    }
+    finally
+    {
+        if ($wuNeeded) { Restore-ADTWindowsUpdateFodAccess }
+    }
+
+    ##================================================
+    ## MARK: Post-Repair
+    ##================================================
+    $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
+
+    if ($restartNeeded) { $adtSession.SetExitCode(3010) }
+}
+
+
+##================================================
+## MARK: Initialization
+##================================================
+
+$ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+Set-StrictMode -Version 1
+
+try
+{
+    if (Test-Path -LiteralPath "$PSScriptRoot\PSAppDeployToolkit\PSAppDeployToolkit.psd1" -PathType Leaf)
+    {
+        Get-ChildItem -LiteralPath "$PSScriptRoot\PSAppDeployToolkit" -Recurse -File | Unblock-File -ErrorAction Ignore
+        Import-Module -FullyQualifiedName @{ ModuleName = "$PSScriptRoot\PSAppDeployToolkit\PSAppDeployToolkit.psd1"; Guid = '8c3c366b-8606-4576-9f2d-4051144f7ca2'; ModuleVersion = '4.1.8' } -Force
+    }
+    else
+    {
+        Import-Module -FullyQualifiedName @{ ModuleName = 'PSAppDeployToolkit'; Guid = '8c3c366b-8606-4576-9f2d-4051144f7ca2'; ModuleVersion = '4.1.8' } -Force
+    }
+
+    $iadtParams = Get-ADTBoundParametersAndDefaultValues -Invocation $MyInvocation
+    $adtSession = Remove-ADTHashtableNullOrEmptyValues -Hashtable $adtSession
+    $adtSession = Open-ADTSession @adtSession @iadtParams -PassThru
+}
+catch
+{
+    $Host.UI.WriteErrorLine((Out-String -InputObject $_ -Width ([System.Int32]::MaxValue)))
+    exit 60008
+}
+
+
+##================================================
+## MARK: Invocation
+##================================================
+
+try
+{
+    Get-ChildItem -LiteralPath $PSScriptRoot -Directory | & {
+        process
+        {
+            if ($_.Name -match 'PSAppDeployToolkit\..+$')
+            {
+                Get-ChildItem -LiteralPath $_.FullName -Recurse -File | Unblock-File -ErrorAction Ignore
+                Import-Module -Name $_.FullName -Force
+            }
+        }
+    }
+
+    & "$($adtSession.DeploymentType)-ADTDeployment"
+    Close-ADTSession
+}
+catch
+{
+    $mainErrorMessage = "An unhandled error within [$($MyInvocation.MyCommand.Name)] has occurred.`n$(Resolve-ADTErrorRecord -ErrorRecord $_)"
+    Write-ADTLogEntry -Message $mainErrorMessage -Severity 3
+    Close-ADTSession -ExitCode 60001
+}
+'@
+
+if (-not $Changelog) { $Changelog = "- 0.1 ($today, $Author): Initial version - enable Windows features (optional features + capabilities)." }
+
+$out = $tpl.
+    Replace('__APPVENDOR__', $AppVendor).
+    Replace('__APPNAME__', $AppName).
+    Replace('__APPVERSION__', $AppVersion).
+    Replace('__AUTHOR__', $Author).
+    Replace('__DATE__', $today).
+    Replace('__CHANGELOG__', $Changelog).
+    Replace('__FEATLITERAL__', $featLiteral)
+
+[System.IO.File]::WriteAllText("$pkg\Invoke-AppDeployToolkit.ps1", $out, [System.Text.UTF8Encoding]::new($true))
+
+# 3) Extensions module (enable/disable dispatch + WU FoD access save/restore). Overwrite the template stub.
+$extModuleDir = Join-Path $pkg 'PSAppDeployToolkit.Extensions'
+if (-not (Test-Path -LiteralPath $extModuleDir)) { New-Item -ItemType Directory -Path $extModuleDir -Force | Out-Null }
+$psd1 = Join-Path $extModuleDir 'PSAppDeployToolkit.Extensions.psd1'
+if (-not (Test-Path -LiteralPath $psd1)) {
+    $manifest = @'
+@{
+    RootModule = 'PSAppDeployToolkit.Extensions.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '7e2b1a4c-3d5f-4e6a-9b8c-1f0d2e3a4b5c'
+    Author = '__AUTHOR__'
+    Description = 'PSAppDeployToolkit extension helpers for Windows-feature packages.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @('Enable-ADTWindowsFeatureItem', 'Disable-ADTWindowsFeatureItem', 'Set-ADTWindowsUpdateFodAccess', 'Restore-ADTWindowsUpdateFodAccess')
+}
+'@
+    [System.IO.File]::WriteAllText($psd1, $manifest.Replace('__AUTHOR__', $Author), [System.Text.UTF8Encoding]::new($true))
+}
+
+$psm1 = @'
+<#
+.SYNOPSIS
+PSAppDeployToolkit.Extensions - Windows-feature helpers (Optional Features + Capabilities/FoD).
+.DESCRIPTION
+Enable/disable dispatch for Enable-WindowsOptionalFeature / Add-WindowsCapability, plus a temporary
+Windows-Update Features-on-Demand access toggle (WSUS bypass) that records and restores the prior state.
+See guide Appendix P.
+#>
+
+$ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+$ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue
+Set-StrictMode -Version 1
+
+# Saved prior state for the WU FoD access toggle (module-scoped, set by Set- and consumed by Restore-).
+$script:AdtFodSaved = @()
+
+function Enable-ADTWindowsFeatureItem
+{
+    <#
+    .SYNOPSIS
+        Enables one Windows optional feature or capability (idempotent). Returns $true if a restart is needed.
+    .PARAMETER Type
+        'OptionalFeature' or 'Capability'.
+    .PARAMETER Name
+        Exact feature name (e.g. NetFx3) or capability name (e.g. Rsat.Dns.Tools~~~~0.0.1.0).
+    .PARAMETER SourcePath
+        Optional path to offline content (e.g. SxS cabs). If it exists, -Source + -LimitAccess is used;
+        otherwise the feature is pulled from Windows Update.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory)][ValidateSet('OptionalFeature', 'Capability')][System.String]$Type,
+        [Parameter(Mandatory)][System.String]$Name,
+        [Parameter()][System.String]$SourcePath = ''
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                $useSource = (-not [string]::IsNullOrWhiteSpace($SourcePath)) -and (Test-Path -LiteralPath $SourcePath)
+                if ($Type -eq 'OptionalFeature')
+                {
+                    $state = (Get-WindowsOptionalFeature -Online -FeatureName $Name -ErrorAction SilentlyContinue).State
+                    if ($state -eq 'Enabled') { Write-ADTLogEntry -Message "Optional feature [$Name] already Enabled; skipping."; return $false }
+                    $p = @{ Online = $true; FeatureName = $Name; All = $true; NoRestart = $true; ErrorAction = 'Stop' }
+                    if ($useSource) { $p.Source = $SourcePath; $p.LimitAccess = $true; Write-ADTLogEntry -Message "Enabling optional feature [$Name] from bundled source [$SourcePath]." }
+                    else { Write-ADTLogEntry -Message "Enabling optional feature [$Name] from Windows Update." }
+                    $r = Enable-WindowsOptionalFeature @p
+                }
+                else
+                {
+                    $state = (Get-WindowsCapability -Online -Name $Name -ErrorAction SilentlyContinue).State
+                    if ($state -eq 'Installed') { Write-ADTLogEntry -Message "Capability [$Name] already Installed; skipping."; return $false }
+                    $p = @{ Online = $true; Name = $Name; ErrorAction = 'Stop' }
+                    if ($useSource) { $p.Source = $SourcePath; $p.LimitAccess = $true; Write-ADTLogEntry -Message "Adding capability [$Name] from bundled source [$SourcePath]." }
+                    else { Write-ADTLogEntry -Message "Adding capability [$Name] from Windows Update." }
+                    $r = Add-WindowsCapability @p
+                }
+                $restart = [bool]($r -and $r.RestartNeeded)
+                Write-ADTLogEntry -Message "[$Name] processed (RestartNeeded=$restart)."
+                return $restart
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+function Disable-ADTWindowsFeatureItem
+{
+    <#
+    .SYNOPSIS
+        Disables one optional feature / removes one capability (idempotent). Returns $true if a restart is needed.
+    .PARAMETER Type
+        'OptionalFeature' or 'Capability'.
+    .PARAMETER Name
+        Exact feature/capability name.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory)][ValidateSet('OptionalFeature', 'Capability')][System.String]$Type,
+        [Parameter(Mandatory)][System.String]$Name
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                if ($Type -eq 'OptionalFeature')
+                {
+                    $state = (Get-WindowsOptionalFeature -Online -FeatureName $Name -ErrorAction SilentlyContinue).State
+                    if ($state -ne 'Enabled' -and $state -ne 'EnablePending') { Write-ADTLogEntry -Message "Optional feature [$Name] not Enabled; nothing to disable."; return $false }
+                    Write-ADTLogEntry -Message "Disabling optional feature [$Name]."
+                    $r = Disable-WindowsOptionalFeature -Online -FeatureName $Name -NoRestart -ErrorAction Stop
+                }
+                else
+                {
+                    $state = (Get-WindowsCapability -Online -Name $Name -ErrorAction SilentlyContinue).State
+                    if ($state -ne 'Installed') { Write-ADTLogEntry -Message "Capability [$Name] not Installed; nothing to remove."; return $false }
+                    Write-ADTLogEntry -Message "Removing capability [$Name]."
+                    $r = Remove-WindowsCapability -Online -Name $Name -ErrorAction Stop
+                }
+                return [bool]($r -and $r.RestartNeeded)
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+function Set-ADTWindowsUpdateFodAccess
+{
+    <#
+    .SYNOPSIS
+        Temporarily allows Features-on-Demand / optional-feature content to come from Windows Update on
+        WSUS-managed devices. Records the prior state so Restore-ADTWindowsUpdateFodAccess can undo it exactly.
+    .DESCRIPTION
+        Sets RepairContentServerSource=2 (Policies\Servicing) and UseWUServer=0 (WindowsUpdate\AU), then
+        restarts wuauserv so the change takes effect. Without this, an Add-WindowsCapability / NetFx3 enable on
+        a WSUS-bound device fails to fetch content (0x800f0950 / 0x800f081f).
+    #>
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                $script:AdtFodSaved = @()
+                $targets = @(
+                    [pscustomobject]@{ Key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Servicing'; Name = 'RepairContentServerSource'; Value = 2 }
+                    [pscustomobject]@{ Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU';          Name = 'UseWUServer';               Value = 0 }
+                )
+                foreach ($t in $targets)
+                {
+                    $keyExisted = Test-Path -LiteralPath $t.Key
+                    $existed = $false
+                    $prior = $null
+                    if ($keyExisted)
+                    {
+                        $cur = Get-ItemProperty -LiteralPath $t.Key -Name $t.Name -ErrorAction SilentlyContinue
+                        if ($cur -and $cur.PSObject.Properties[$t.Name]) { $existed = $true; $prior = $cur.$($t.Name) }
+                    }
+                    else
+                    {
+                        New-Item -Path $t.Key -Force | Out-Null
+                    }
+                    $script:AdtFodSaved += [pscustomobject]@{ Key = $t.Key; Name = $t.Name; KeyExisted = $keyExisted; Existed = $existed; Prior = $prior }
+                    New-ItemProperty -LiteralPath $t.Key -Name $t.Name -Value $t.Value -PropertyType DWord -Force | Out-Null
+                    Write-ADTLogEntry -Message "WU FoD access: set [$($t.Key)\$($t.Name)] = $($t.Value) (prior existed=$existed)."
+                }
+                try { Restart-Service -Name wuauserv -Force -ErrorAction SilentlyContinue } catch { }
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+function Restore-ADTWindowsUpdateFodAccess
+{
+    <#
+    .SYNOPSIS
+        Restores the exact prior state changed by Set-ADTWindowsUpdateFodAccess (re-set prior value, or remove
+        the value if it did not exist before). Keys created by Set- are left in place (harmless, empty policy).
+    #>
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    begin { Initialize-ADTFunction -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState }
+
+    process
+    {
+        try
+        {
+            try
+            {
+                if (-not $script:AdtFodSaved -or @($script:AdtFodSaved).Count -eq 0) { return }
+                foreach ($s in $script:AdtFodSaved)
+                {
+                    if (-not (Test-Path -LiteralPath $s.Key)) { continue }
+                    if ($s.Existed)
+                    {
+                        New-ItemProperty -LiteralPath $s.Key -Name $s.Name -Value $s.Prior -PropertyType DWord -Force | Out-Null
+                        Write-ADTLogEntry -Message "WU FoD access: restored [$($s.Key)\$($s.Name)] = $($s.Prior)."
+                    }
+                    else
+                    {
+                        Remove-ItemProperty -LiteralPath $s.Key -Name $s.Name -Force -ErrorAction SilentlyContinue
+                        Write-ADTLogEntry -Message "WU FoD access: removed temporary [$($s.Key)\$($s.Name)]."
+                    }
+                }
+                $script:AdtFodSaved = @()
+                try { Restart-Service -Name wuauserv -Force -ErrorAction SilentlyContinue } catch { }
+            }
+            catch
+            {
+                Write-Error -ErrorRecord $_
+            }
+        }
+        catch
+        {
+            Invoke-ADTFunctionErrorHandler -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState -ErrorRecord $_
+        }
+    }
+
+    end { Complete-ADTFunction -Cmdlet $PSCmdlet }
+}
+
+Write-ADTLogEntry -Message "Module [$($MyInvocation.MyCommand.ScriptBlock.Module.Name)] imported successfully." -ScriptSection Initialization
+'@
+[System.IO.File]::WriteAllText((Join-Path $extModuleDir 'PSAppDeployToolkit.Extensions.psm1'), $psm1, [System.Text.UTF8Encoding]::new($true))
+
+# 4) Detection script - verifies each feature reached its target state (Enabled / Installed).
+$detect = @'
+# Detect-__NAME__.ps1 - Intune detection for __APPNAME__ (__APPVERSION__).
+# Reports installed only when EVERY managed feature is in its target state (OptionalFeature -> Enabled,
+# Capability -> Installed). A feature pending a reboot shows EnablePending and is treated as NOT yet done;
+# Intune re-detects after the 3010 reboot. Run as System, 64-bit (Run as 32-bit = No).
+# Contract: stdout + exit 0 when all present; otherwise no output + exit 0.
+
+$feats = __FEATLITERAL__
+
+$found = @()
+$allOk = $true
+foreach ($f in $feats)
+{
+    if ($f.Type -eq 'OptionalFeature')
+    {
+        $state = (Get-WindowsOptionalFeature -Online -FeatureName $f.Name -ErrorAction SilentlyContinue).State
+        if ($state -eq 'Enabled') { $found += "OptionalFeature:$($f.Name)" } else { $allOk = $false }
+    }
+    else
+    {
+        $state = (Get-WindowsCapability -Online -Name $f.Name -ErrorAction SilentlyContinue).State
+        if ($state -eq 'Installed') { $found += "Capability:$($f.Name)" } else { $allOk = $false }
+    }
+}
+
+if ($allOk -and $found.Count -gt 0)
+{
+    Write-Output ("Detected Windows features: " + ($found -join ', '))
+    exit 0
+}
+exit 0
+'@
+$detect = $detect.
+    Replace('__NAME__', $Name).
+    Replace('__APPNAME__', $AppName).
+    Replace('__APPVERSION__', $AppVersion).
+    Replace('__FEATLITERAL__', $featLiteral)
+[System.IO.File]::WriteAllText("$pkg\Detect-$Name.ps1", $detect, [System.Text.UTF8Encoding]::new($true))
+
+Write-Output "PACKAGE_OK: $pkg"
+Write-Output "Next: Phase 5 pre-flight (scripts/Invoke-PsadtPreflight.ps1 -PackagePath '$pkg') -> Phase 7 package -> Phase 8 dossier."


### PR DESCRIPTION
## Summary
Adds a new **opt-in package type**: enable additional **Windows features** as an Intune Win32 app — covering **both** mechanisms in one generator (multiple per package):
- **Optional Features** (`Enable-WindowsOptionalFeature`) — NetFx3, Hyper-V, WSL, TelnetClient, …
- **Capabilities / Features on Demand** (`Add-WindowsCapability`) — RSAT.*, OpenSSH, …

Feature-only (no vendor installer). `Files\` empty unless you bundle an offline source.

## What's included
- **`scripts/New-WindowsFeaturePackage.ps1`** — one-call generator: launcher (data model + 3 hooks), Extensions module (enable/disable dispatch + temporary WU Features-on-Demand access toggle), detection script.
- **Guide Appendix P** — model, Phase-2 name/reboot/source research, cmdlet+state reference, helpers, hooks, detection + Intune wiring, content source, anti-patterns.
- **SKILL.md** — Gate-1 package-type option, Phase-2 note, anti-patterns, reference-lookup line.
- README project tree + CHANGELOG (0.15.0).

## Behaviour
- **Uninstall reverts** (`Disable-WindowsOptionalFeature` / `Remove-WindowsCapability`); Repair re-enables (idempotent); helpers skip features already in the target state.
- **Reboot:** `RestartNeeded` → `$adtSession.SetExitCode(3010)`; `-NoRestart` prevents DISM rebooting mid-install; detection treats `EnablePending` as not-yet-done.
- **Content source:** bundled `Files\<Source>` via `-Source -LimitAccess` (offline), else Windows Update behind a **temporary** WSUS bypass (`RepairContentServerSource=2`, `UseWUServer=0`) whose exact prior state is recorded and restored — the proven pattern from the existing `RSAT-1.0.0` package.

## Verification
- Generated package passes the Phase-5 pre-flight **GREEN**.
- Enable/disable dispatch, idempotency, clean boolean returns, and the WU-FoD save/restore (incl. removing a value that did not exist before) validated against an in-memory registry sim.
- Generator is 7-bit ASCII-clean.

## ⚠️ Stacked PR
This branch is stacked on **#5** (browser-extension packages) — it shares the SKILL.md / guide / CHANGELOG regions. **Base is `feat/browser-extension-packages`** so this diff shows only the windows-features changes. Merge #5 first; this will then retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
