### PR TITLE
fix(skill): generator hardening — escaping, detection contract, WSUS, stale refs (0.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.15.1 — 2026-06-15 — Generator hardening from a self-review (correctness + security)
+
+### Fixed
+- **Apostrophe in App name/vendor/author produced an unparseable package.** All three generators now
+  single-quote-escape every value embedded in a single-quoted `$adtSession` literal (`AppName`, `AppVendor`,
+  `AppVersion`, `AppScriptAuthor`) — so "Bob's App" / "L'Oreal" no longer break the generated script. The MSI
+  generator's `-AdditionalArgumentList` and `ProcessesToClose` literals are escaped too (this also closes a
+  code-injection path into a script that runs as SYSTEM). The MSI desktop-shortcut path keeps the raw name
+  (valid inside a double-quoted string) via a dedicated token.
+- **Detection exit-code contract drift.** `New-MsiPackage.ps1` and the WinGet detection example (Appendix I)
+  emitted `exit 1` for "not installed"; per the contract (stated in SKILL.md / 8.5 / App. A) that path must be
+  `exit 0` + empty stdout (a non-zero exit reads as a detection *error/retry*). Both now `exit 0`. The newer
+  Browser/Feature generators were already correct.
+- **WSUS-bypass could be left on permanently.** In `New-WindowsFeaturePackage.ps1`, `Set-ADTWindowsUpdateFodAccess`
+  now records the prior state of *all* targets before writing any (a partial write is fully reversible), and the
+  install/repair hooks call it *inside* the `try` so the `finally` always restores `RepairContentServerSource` /
+  `UseWUServer` even if the toggle itself throws.
+
+### Added
+- **Pre-flight check 7 (Detection).** `Invoke-PsadtPreflight.ps1` now scans `Detect*.ps1` and WARNs on a
+  non-zero `exit` (the "not installed" path should be `exit 0`). WARN-only — does not flip GREEN.
+- **Input guards in all three generators:** reject a `$Name` containing path separators or `..` (before the
+  `Remove-Item -Recurse` scaffold step), and reject any free-text parameter containing a `__TOKEN__` sequence
+  that would corrupt the `.Replace()` templating.
+- `New-MsiPackage.ps1` now resolves `$Author` from config when omitted (parity with the other generators) and
+  validates `-InstallerPath` exists before scaffolding.
+
+### Fixed (docs)
+- Stale `SKILL.md` intro range "Appendix A-M" -> "A-P"; `New-PsadtEntraApp.ps1` "Phase 7.5" -> "Phase 9".
+
 ## 0.15.0 — 2026-06-15 — Windows-feature packages (optional features + capabilities / FoD)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ configurable per machine.
 Notable changes to the skill, newest first. Append-only — entries are never removed. Also mirrored in
 **[CHANGELOG.md](CHANGELOG.md)**.
 
+### 0.15.1 - 15.06.2026
+- **Generator hardening from a self-review (correctness + security).** All three generators now single-quote-escape
+  values embedded in `$adtSession` literals, so an apostrophe in the App name/vendor/author (e.g. "Bob's App",
+  "L'Oreal") no longer produces an unparseable package; the MSI `-AdditionalArgumentList` / `ProcessesToClose`
+  literals are escaped too (also closing a SYSTEM code-injection path). Detection exit-code drift fixed:
+  `New-MsiPackage.ps1` + the WinGet example now `exit 0` for "not installed" (a non-zero exit reads as a detection
+  error), and a new **pre-flight Detection check** WARNs on a non-zero exit in `Detect*.ps1`. The WSUS bypass in
+  `New-WindowsFeaturePackage.ps1` now saves all prior state before writing and runs inside the `try/finally`, so a
+  partial failure can't leave `UseWUServer=0` permanently. Added input guards (`$Name` path-traversal, `__TOKEN__`
+  leak), MSI `-Author` config fallback + `-InstallerPath` validation. Stale refs fixed (SKILL.md "A-M"->"A-P",
+  `New-PsadtEntraApp.ps1` "Phase 7.5"->"Phase 9").
+
 ### 0.15.0 - 15.06.2026
 - **Windows-feature packages (optional features + capabilities / FoD).** New `scripts/New-WindowsFeaturePackage.ps1`
   — one-call generator that enables Windows **Optional Features** (`Enable-WindowsOptionalFeature`: NetFx3,

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ description: Use when the user wants to build, package, test, troubleshoot, or d
 # PSADT v4.x Deployment Skill
 
 Drive a PSADT v4.x Intune Win32 package end-to-end. Depth lives in
-`references/PSADTv4-Deployment-Guide.md` (Phases 0-12 + Appendix A-M) and in each script's comment-based
+`references/PSADTv4-Deployment-Guide.md` (Phases 0-12 + Appendix A-P) and in each script's comment-based
 help. Keep THIS file as the control plane; load guide sections on demand instead of inlining them.
 
 ## Operating mode (autonomy first)

--- a/references/PSADTv4-Deployment-Guide.md
+++ b/references/PSADTv4-Deployment-Guide.md
@@ -1316,7 +1316,7 @@ foreach ($base in $regBases) {
         Where-Object { $_.DisplayName -like '<AppName>*' } | Select-Object -First 1
     if ($match) { Write-Output "Detected: $($match.DisplayName) $($match.DisplayVersion)"; exit 0 }
 }
-exit 1
+exit 0   # not installed: no stdout + exit 0 (a non-zero exit reads as a detection error/retry, not "absent")
 ```
 For a stable manifest `ProductCode`, use the direct GUID key (`HKLM:\...\Uninstall\{<ProductCode>}`).
 

--- a/scripts/Invoke-PsadtPreflight.ps1
+++ b/scripts/Invoke-PsadtPreflight.ps1
@@ -18,6 +18,8 @@
                       defined is actually called by the launcher (else WARN).
       6. ProductCode- no `Start-ADTMsiProcess -FilePath '{GUID}'` (a GUID belongs on -ProductCode; a GUID on
                       -FilePath throws InvalidFilePathParameterValue -> 60001). Checked in all hooks.
+      7. Detection  - any Detect*.ps1 in the package: the "not installed" path should be `exit 0` + empty stdout
+                      (Intune reads a non-zero exit as a detection error/retry, not "absent"). Non-zero exit = WARN.
 
     GREEN = no FAIL checks. WARN does not flip the verdict. Works under Windows PowerShell 5.1 and PowerShell 7.
 
@@ -155,6 +157,19 @@ else {
     }
     if ($suspect.Count -gt 0) { Add-Check 'TopLevel' 'WARN' "$($suspect.Count) unexpected top-level statement(s) - review: $((($suspect | Select-Object -First 3) -join ' | '))" 'Invoke-AppDeployToolkit.ps1' }
     else { Add-Check 'TopLevel' 'PASS' 'no unexpected top-level statements' 'Invoke-AppDeployToolkit.ps1' }
+}
+
+# --- 7: detection script exit-code contract (WARN-only) -------------------------------------------
+$detectFiles = @(Get-ChildItem -Path $PackagePath -Filter 'Detect*.ps1' -ErrorAction SilentlyContinue | ForEach-Object FullName)
+foreach ($df in $detectFiles) {
+    $leaf = Split-Path $df -Leaf
+    $dtxt = Get-Content $df -Raw
+    if ($dtxt -match '(?m)^\s*exit\s+[1-9]') {
+        Add-Check 'Detection' 'WARN' 'non-zero exit in detection script - the "not installed" path should be exit 0 + empty stdout (Intune reads a non-zero exit as a detection error/retry, not "absent")' $leaf
+    }
+    else {
+        Add-Check 'Detection' 'PASS' 'exit-code contract OK (exit 0 paths only)' $leaf
+    }
 }
 
 # --- Verdict --------------------------------------------------------------------------------------

--- a/scripts/New-BrowserExtensionPackage.ps1
+++ b/scripts/New-BrowserExtensionPackage.ps1
@@ -57,6 +57,17 @@ if (-not $Author) {
 }
 $today = (Get-Item $PSCommandPath).LastWriteTime.ToString('yyyy-MM-dd')  # avoid Get-Date (sandbox)
 
+# Escape a value for embedding inside a single-quoted PowerShell literal (double internal quotes).
+function Get-SqEscaped([string]$s) { ($s -replace "'", "''") }
+# Reject a value that contains a template placeholder - it would corrupt the .Replace() templating.
+function Assert-NoTokenLeak([string]$value, [string]$paramName) {
+    if ($value -match '__[A-Z0-9_]+__') { throw "Parameter '$paramName' must not contain a template placeholder sequence ('$($Matches[0])')." }
+}
+if ($Name -match '[\\/:*?"<>|]' -or $Name -match '\.\.') { throw "Name '$Name' must be a simple folder name (no path separators or '..')." }
+foreach ($pair in @(@('Name', $Name), @('AppVendor', $AppVendor), @('AppName', $AppName), @('AppVersion', $AppVersion), @('Author', $Author), @('Changelog', $Changelog))) {
+    Assert-NoTokenLeak ([string]$pair[1]) $pair[0]
+}
+
 # --- Validate + normalize the extension list ------------------------------------------------------
 $chromiumIdPattern = '^[a-p]{32}$'
 $norm = foreach ($ext in $Extensions) {
@@ -340,10 +351,10 @@ catch
 if (-not $Changelog) { $Changelog = "- 0.1 ($today, $Author): Initial version - force-install browser extensions via policy registry keys." }
 
 $out = $tpl.
-    Replace('__APPVENDOR__', $AppVendor).
-    Replace('__APPNAME__', $AppName).
-    Replace('__APPVERSION__', $AppVersion).
-    Replace('__AUTHOR__', $Author).
+    Replace('__APPVENDOR__', (Get-SqEscaped $AppVendor)).
+    Replace('__APPNAME__', (Get-SqEscaped $AppName)).
+    Replace('__APPVERSION__', (Get-SqEscaped $AppVersion)).
+    Replace('__AUTHOR__', (Get-SqEscaped $Author)).
     Replace('__DATE__', $today).
     Replace('__CHANGELOG__', $Changelog).
     Replace('__EXTLITERAL__', $extLiteral)
@@ -366,7 +377,7 @@ if (-not (Test-Path -LiteralPath $psd1)) {
     FunctionsToExport = @('Set-ADTChromiumForcelistEntry', 'Remove-ADTChromiumForcelistEntry', 'Set-ADTFirefoxExtensionSetting', 'Remove-ADTFirefoxExtensionSetting')
 }
 '@
-    [System.IO.File]::WriteAllText($psd1, $manifest.Replace('__AUTHOR__', $Author), [System.Text.UTF8Encoding]::new($true))
+    [System.IO.File]::WriteAllText($psd1, $manifest.Replace('__AUTHOR__', (Get-SqEscaped $Author)), [System.Text.UTF8Encoding]::new($true))
 }
 
 $psm1 = @'

--- a/scripts/New-MsiPackage.ps1
+++ b/scripts/New-MsiPackage.ps1
@@ -27,15 +27,31 @@ $ErrorActionPreference = 'Stop'
 Import-Module PSAppDeployToolkit -Force
 
 if (-not $PackageRoot) { $PackageRoot = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1')).Config.paths.packageRoot }
+if (-not $Author) {
+    $cfg = (& (Join-Path $PSScriptRoot 'Get-PsadtConfig.ps1')).Config
+    if ($cfg) { $Author = "$($cfg.author.person), $($cfg.author.company)" }
+}
 $today = (Get-Item $PSCommandPath).LastWriteTime.ToString('yyyy-MM-dd')  # avoid Get-Date (sandbox)
+
+# Escape a value for embedding inside a single-quoted PowerShell literal (double internal quotes).
+function Get-SqEscaped([string]$s) { ($s -replace "'", "''") }
+# Reject a value that contains a template placeholder - it would corrupt the .Replace() templating.
+function Assert-NoTokenLeak([string]$value, [string]$paramName) {
+    if ($value -match '__[A-Z0-9_]+__') { throw "Parameter '$paramName' must not contain a template placeholder sequence ('$($Matches[0])')." }
+}
+if ($Name -match '[\\/:*?"<>|]' -or $Name -match '\.\.') { throw "Name '$Name' must be a simple folder name (no path separators or '..')." }
+foreach ($pair in @(@('Name', $Name), @('AppVendor', $AppVendor), @('AppName', $AppName), @('AppVersion', $AppVersion), @('Author', $Author), @('AdditionalArgs', $AdditionalArgs), @('InstallerFile', $InstallerFile), @('DisplayNameLike', $DisplayNameLike), @('Changelog', $Changelog))) {
+    Assert-NoTokenLeak ([string]$pair[1]) $pair[0]
+}
+if (-not (Test-Path -LiteralPath $InstallerPath)) { throw "InstallerPath not found: $InstallerPath" }
 
 # 1) Scaffold
 $pkg = Join-Path $PackageRoot $Name
 if (Test-Path $pkg) { Remove-Item $pkg -Recurse -Force }
 New-ADTTemplate -Destination $PackageRoot -Name $Name -Force | Out-Null
 
-# 2) Process list literal
-$procLiteral = if ($ProcessesToClose.Count -gt 0) { "@(" + (($ProcessesToClose | ForEach-Object { "'$_'" }) -join ', ') + ")" } else { "@()" }
+# 2) Process list literal (single-quote-escaped so a name with an apostrophe cannot break the literal)
+$procLiteral = if ($ProcessesToClose.Count -gt 0) { "@(" + (($ProcessesToClose | ForEach-Object { "'$(Get-SqEscaped $_)'" }) -join ', ') + ")" } else { "@()" }
 
 # 3) Build the customized script
 $tpl = @'
@@ -133,7 +149,7 @@ function Install-ADTDeployment
     $adtSession.InstallPhase = "Post-$($adtSession.DeploymentType)"
 
     ## Remove any desktop shortcut the installer may have created (Start Menu only policy).
-    foreach ($lnk in @("$env:Public\Desktop\__APPNAME__.lnk"))
+    foreach ($lnk in @("$env:Public\Desktop\__APPNAME_FILE__.lnk"))
     {
         if (Test-Path -LiteralPath $lnk) { Remove-Item -LiteralPath $lnk -Force -ErrorAction SilentlyContinue }
     }
@@ -262,17 +278,20 @@ catch
 '@
 
 if (-not $Changelog) { $Changelog = "- 0.1 ($today, $Author): Initial version." }
-$addArgsLine = if ($AdditionalArgs) { " -AdditionalArgumentList '$AdditionalArgs'" } else { '' }
+$addArgsLine = if ($AdditionalArgs) { " -AdditionalArgumentList '$(Get-SqEscaped $AdditionalArgs)'" } else { '' }
 
+# Values that land in single-quoted $adtSession literals are single-quote-escaped; __APPNAME_FILE__ is the
+# raw name for the double-quoted desktop-shortcut path (apostrophes are valid inside a double-quoted string).
 $out = $tpl.
-    Replace('__APPVENDOR__', $AppVendor).
-    Replace('__APPNAME__', $AppName).
-    Replace('__APPVERSION__', $AppVersion).
-    Replace('__APPARCH__', $AppArch).
+    Replace('__APPVENDOR__', (Get-SqEscaped $AppVendor)).
+    Replace('__APPNAME_FILE__', $AppName).
+    Replace('__APPNAME__', (Get-SqEscaped $AppName)).
+    Replace('__APPVERSION__', (Get-SqEscaped $AppVersion)).
+    Replace('__APPARCH__', (Get-SqEscaped $AppArch)).
     Replace('__PROCESSES__', $procLiteral).
-    Replace('__AUTHOR__', $Author).
+    Replace('__AUTHOR__', (Get-SqEscaped $Author)).
     Replace('__DATE__', $today).
-    Replace('__INSTALLER__', $InstallerFile).
+    Replace('__INSTALLER__', (Get-SqEscaped $InstallerFile)).
     Replace('__ADDARGSLINE__', $addArgsLine).
     Replace('__PRODUCTCODE__', $ProductCode).
     Replace('__CHANGELOG__', $Changelog)
@@ -300,7 +319,8 @@ foreach ($k in $keys)
         exit 0
     }
 }
-exit 1
+# Not installed: emit nothing and exit 0 (Intune detection contract; a non-zero exit reads as a detection error).
+exit 0
 '@
 $detect = $detect.Replace('__NAME__', $Name).Replace('__APPNAME__', $AppName).Replace('__APPVERSION__', $AppVersion).Replace('__PRODUCTCODE__', $ProductCode)
 [System.IO.File]::WriteAllText("$pkg\Detect-$Name.ps1", $detect, [System.Text.UTF8Encoding]::new($true))

--- a/scripts/New-PsadtEntraApp.ps1
+++ b/scripts/New-PsadtEntraApp.ps1
@@ -357,7 +357,7 @@ if ($UseCertificate) {
 if (-not $consentGranted) {
     Write-Host "  ACTION    : grant admin consent in the portal before the first upload." -ForegroundColor Yellow
 }
-Write-Host "Next: build a package; the upload step (Phase 7.5) will use this app." -ForegroundColor Gray
+Write-Host "Next: build a package; the upload step (Phase 9) will use this app." -ForegroundColor Gray
 Write-Host "----------------------------------------------------------------`n" -ForegroundColor DarkGray
 
 [pscustomobject]@{

--- a/scripts/New-WindowsFeaturePackage.ps1
+++ b/scripts/New-WindowsFeaturePackage.ps1
@@ -52,6 +52,17 @@ if (-not $Author) {
 }
 $today = (Get-Item $PSCommandPath).LastWriteTime.ToString('yyyy-MM-dd')  # avoid Get-Date (sandbox)
 
+# Escape a value for embedding inside a single-quoted PowerShell literal (double internal quotes).
+function Get-SqEscaped([string]$s) { ($s -replace "'", "''") }
+# Reject a value that contains a template placeholder - it would corrupt the .Replace() templating.
+function Assert-NoTokenLeak([string]$value, [string]$paramName) {
+    if ($value -match '__[A-Z0-9_]+__') { throw "Parameter '$paramName' must not contain a template placeholder sequence ('$($Matches[0])')." }
+}
+if ($Name -match '[\\/:*?"<>|]' -or $Name -match '\.\.') { throw "Name '$Name' must be a simple folder name (no path separators or '..')." }
+foreach ($pair in @(@('Name', $Name), @('AppVendor', $AppVendor), @('AppName', $AppName), @('AppVersion', $AppVersion), @('Author', $Author), @('Changelog', $Changelog))) {
+    Assert-NoTokenLeak ([string]$pair[1]) $pair[0]
+}
+
 # --- Validate + normalize the feature list --------------------------------------------------------
 $norm = foreach ($f in $Features) {
     $type = [string]$f.Type
@@ -171,9 +182,10 @@ function Install-ADTDeployment
     ## WSUS-managed devices, and always restore the prior state in the finally block.
     $restartNeeded = $false
     $wuNeeded = @($script:WindowsFeatures | Where-Object { [string]::IsNullOrWhiteSpace($_.Source) }).Count -gt 0
-    if ($wuNeeded) { Set-ADTWindowsUpdateFodAccess }
     try
     {
+        ## Set inside the try so the finally always restores the WU/WSUS state, even if Set- itself throws.
+        if ($wuNeeded) { Set-ADTWindowsUpdateFodAccess }
         foreach ($f in $script:WindowsFeatures)
         {
             $src = ''
@@ -259,9 +271,10 @@ function Repair-ADTDeployment
     ## Idempotent re-enable (same as install). Helpers skip features already in the target state.
     $restartNeeded = $false
     $wuNeeded = @($script:WindowsFeatures | Where-Object { [string]::IsNullOrWhiteSpace($_.Source) }).Count -gt 0
-    if ($wuNeeded) { Set-ADTWindowsUpdateFodAccess }
     try
     {
+        ## Set inside the try so the finally always restores the WU/WSUS state, even if Set- itself throws.
+        if ($wuNeeded) { Set-ADTWindowsUpdateFodAccess }
         foreach ($f in $script:WindowsFeatures)
         {
             $src = ''
@@ -345,10 +358,10 @@ catch
 if (-not $Changelog) { $Changelog = "- 0.1 ($today, $Author): Initial version - enable Windows features (optional features + capabilities)." }
 
 $out = $tpl.
-    Replace('__APPVENDOR__', $AppVendor).
-    Replace('__APPNAME__', $AppName).
-    Replace('__APPVERSION__', $AppVersion).
-    Replace('__AUTHOR__', $Author).
+    Replace('__APPVENDOR__', (Get-SqEscaped $AppVendor)).
+    Replace('__APPNAME__', (Get-SqEscaped $AppName)).
+    Replace('__APPVERSION__', (Get-SqEscaped $AppVersion)).
+    Replace('__AUTHOR__', (Get-SqEscaped $Author)).
     Replace('__DATE__', $today).
     Replace('__CHANGELOG__', $Changelog).
     Replace('__FEATLITERAL__', $featLiteral)
@@ -371,7 +384,7 @@ if (-not (Test-Path -LiteralPath $psd1)) {
     FunctionsToExport = @('Enable-ADTWindowsFeatureItem', 'Disable-ADTWindowsFeatureItem', 'Set-ADTWindowsUpdateFodAccess', 'Restore-ADTWindowsUpdateFodAccess')
 }
 '@
-    [System.IO.File]::WriteAllText($psd1, $manifest.Replace('__AUTHOR__', $Author), [System.Text.UTF8Encoding]::new($true))
+    [System.IO.File]::WriteAllText($psd1, $manifest.Replace('__AUTHOR__', (Get-SqEscaped $Author)), [System.Text.UTF8Encoding]::new($true))
 }
 
 $psm1 = @'
@@ -543,6 +556,8 @@ function Set-ADTWindowsUpdateFodAccess
                     [pscustomobject]@{ Key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Servicing'; Name = 'RepairContentServerSource'; Value = 2 }
                     [pscustomobject]@{ Key = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU';          Name = 'UseWUServer';               Value = 0 }
                 )
+                # Phase 1: record the prior state of EVERY target before changing anything, so a partial write
+                # (e.g. the 2nd New-ItemProperty throws on a locked key) is still fully reversible by Restore-.
                 foreach ($t in $targets)
                 {
                     $keyExisted = Test-Path -LiteralPath $t.Key
@@ -553,13 +568,14 @@ function Set-ADTWindowsUpdateFodAccess
                         $cur = Get-ItemProperty -LiteralPath $t.Key -Name $t.Name -ErrorAction SilentlyContinue
                         if ($cur -and $cur.PSObject.Properties[$t.Name]) { $existed = $true; $prior = $cur.$($t.Name) }
                     }
-                    else
-                    {
-                        New-Item -Path $t.Key -Force | Out-Null
-                    }
                     $script:AdtFodSaved += [pscustomobject]@{ Key = $t.Key; Name = $t.Name; KeyExisted = $keyExisted; Existed = $existed; Prior = $prior }
+                }
+                # Phase 2: apply (create the key if needed, then set the value).
+                foreach ($t in $targets)
+                {
+                    if (!(Test-Path -LiteralPath $t.Key)) { New-Item -Path $t.Key -Force | Out-Null }
                     New-ItemProperty -LiteralPath $t.Key -Name $t.Name -Value $t.Value -PropertyType DWord -Force | Out-Null
-                    Write-ADTLogEntry -Message "WU FoD access: set [$($t.Key)\$($t.Name)] = $($t.Value) (prior existed=$existed)."
+                    Write-ADTLogEntry -Message "WU FoD access: set [$($t.Key)\$($t.Name)] = $($t.Value)."
                 }
                 try { Restart-Service -Name wuauserv -Force -ErrorAction SilentlyContinue } catch { }
             }


### PR DESCRIPTION
Correctness + security fixes from an honest self-review of the skill.

**Fixed**
- **Apostrophe bug:** all 3 generators single-quote-escape values in `$adtSession` literals — "Bob's App" / "L'Oreal" no longer produce an unparseable package. MSI `-AdditionalArgumentList` + `ProcessesToClose` escaped too (closes a SYSTEM code-injection path); shortcut path uses a raw `__APPNAME_FILE__` token (valid in double quotes).
- **Detection contract drift:** `New-MsiPackage.ps1` + WinGet example now `exit 0` for not-installed (non-zero = detection error). New pre-flight **check 7 (Detection)** WARNs on a non-zero exit in `Detect*.ps1`.
- **WSUS bypass:** `Set-ADTWindowsUpdateFodAccess` saves all prior state before writing, and runs inside the `try` so `finally` always restores — no permanently-disabled WSUS after a mid-op failure.

**Added guards:** `$Name` path-traversal reject; `__TOKEN__`-leak reject; MSI `-Author` config fallback + `-InstallerPath` validation.

**Docs:** SKILL.md "Appendix A-M"->"A-P"; `New-PsadtEntraApp.ps1` "Phase 7.5"->"Phase 9".

**Verified:** apostrophe packages pre-flight GREEN, 0 parse errors; guards throw; detection probe WARNs; WSUS save/restore exact; all edited scripts ASCII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)