### PR TITLE
docs: changelog 0.15.2 (record report phase-ref fix in CHANGELOG + README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.15.2 — 2026-06-15 — Follow-up: one more stale phase reference
+
+### Fixed (docs)
+- A contradiction sweep after 0.15.1 found a residual stale **"Phase 7.5"** in `New-PsadtReport.ps1`
+  comment-based help - upload is **Phase 9**. 0.15.1 had only corrected `New-PsadtEntraApp.ps1`. No other live
+  stale references remain (verified across all `.ps1`/`.md`; the `exit 1` occurrences left in the guide are
+  legitimate prose / the fix-script "couldn't run" guard, not detection paths).
+
 ## 0.15.1 — 2026-06-15 — Generator hardening from a self-review (correctness + security)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ configurable per machine.
 Notable changes to the skill, newest first. Append-only — entries are never removed. Also mirrored in
 **[CHANGELOG.md](CHANGELOG.md)**.
 
+### 0.15.2 - 15.06.2026
+- **Follow-up doc fix.** A contradiction sweep after 0.15.1 caught one more stale "Phase 7.5" in
+  `New-PsadtReport.ps1` help (upload is Phase 9); corrected. No other live stale references remain.
+
 ### 0.15.1 - 15.06.2026
 - **Generator hardening from a self-review (correctness + security).** All three generators now single-quote-escape
   values embedded in `$adtSession` literals, so an apostrophe in the App name/vendor/author (e.g. "Bob's App",


### PR DESCRIPTION
Records the 0.15.x `New-PsadtReport.ps1` stale-ref fix in both CHANGELOG.md and the README changelog mirror (PR #10 landed without an entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)