### PR TITLE
install4j fingerprint + behavioral silent-switch verification (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.17.0 — 2026-07-01 — install4j fingerprint + behavioral silent-switch verification
+
+### Added
+- **install4j installer fingerprint (Appendix L.1).** Recognise install4j (Java) installers by
+  `com/install4j/runtime` / `exe4j` / `i4jparams.conf` / `-Duser.language` strings and a bundled `jre\` in the
+  extracted `e4j*.tmp_dir*`. Records that **`/S` is NOT its switch** — passing `/S` shows the language-selection
+  dialog and hangs forever; the unattended switch is **`-q`**, and it needs elevation or it stalls. Also sharpened
+  the InstallShield fingerprint (`ISSetupStream`, Basic-MSI vs InstallScript).
+- **BINDING rule: a single string match is a hint, not proof (Appendix L.1).** Confirm the engine by its
+  definitive fingerprint AND **behaviorally verify the silent switch** — run `installer <switch>` once with a
+  timeout + window/exit watch (kill on timeout) and confirm exit 0 with no dialog — BEFORE building the package.
+- **Trademark-sign gotcha in DisplayName filters (Appendix L.3).** A `(R)`/`(TM)` sign (e.g.
+  `Aperio(R) Programming Application`) breaks a literal `-match 'Name'`, so `Uninstall-ADTApplication` /
+  `Get-ADTApplication` find nothing and silently no-op; use a tolerant regex (`-match 'Name.*Rest'`).
+- **Anti-patterns 13–15 (Appendix B).** Guessing the installer engine from a lone string match without ever
+  running it; a trademark sign breaking a DisplayName filter; shipping a driver/cert as a note instead of a
+  bundled deliverable (extract the signer `.cer`, import to TrustedPublisher in Pre-Install).
+
+### Changed
+- **Appendix L.2 install4j row corrected** (`-q`, elevation, empty QuietUninstallString → append `-q` via
+  `-AdditionalArgumentList`, bundled JRE, dpinst driver-cert pre-trust); IzPack split into its own row.
+
+_Driven by real-world friction: an ASSA ABLOY Aperio install4j installer carried a coincidental `nsis` string,
+was mistaken for NSIS, and `/S` hung on the language dialog during install._
+
 ## 0.16.0 — 2026-06-29 — Dossier stays in sync after script changes + report header layout fix
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ configurable per machine.
 Notable changes to the skill, newest first. Append-only — entries are never removed. Also mirrored in
 **[CHANGELOG.md](CHANGELOG.md)**.
 
+### 0.17.0 - 01.07.2026
+- **install4j fingerprint + behavioral silent-switch verification.** Appendix L.1 now recognises install4j
+  (Java) installers (`com/install4j/runtime`, `exe4j`, `i4jparams.conf`, bundled `jre\`) and records that `/S`
+  is NOT its switch (it hangs on the language dialog) — the unattended switch is `-q`, run elevated. New BINDING
+  rule: a single string match is a hint, not proof; confirm the engine by its definitive fingerprint AND run the
+  silent switch once (timeout+kill, expect exit 0, no dialog) before packaging. Appendix L.3 adds the
+  trademark-sign gotcha (`Name(R)` breaks `-match 'Name'` → tolerant regex); Appendix B adds anti-patterns 13–15.
+  (Driven by an Aperio install4j installer misidentified as NSIS, where `/S` hung on the language dialog.)
+
+### 0.16.0 - 29.06.2026
+- **Dossier auto-sync convention (BINDING)** + report header layout fix. Any change to the package scripts
+  (launcher, Extensions, detection, version/changelog, return codes, re-packaging) now requires regenerating
+  `Intune-Dossier.html` in the same pass; a stale dossier is a defect. The `.pill-lg` status badge caps at 230px
+  and wraps so a long status no longer overlaps the hero title.
+
 ### 0.15.2 - 15.06.2026
 - **Follow-up doc fix.** A contradiction sweep after 0.15.1 caught one more stale "Phase 7.5" in
   `New-PsadtReport.ps1` help (upload is Phase 9); corrected. No other live stale references remain.

--- a/references/PSADTv4-Deployment-Guide.md
+++ b/references/PSADTv4-Deployment-Guide.md
@@ -732,6 +732,15 @@ AppWorkload.log sequence:
 10. **Extensions in the main script instead of in `PSAppDeployToolkit.Extensions`**.
 11. **-o inside -c with IntuneWinAppUtil** - nested .intunewin.
 12. **No stakeholder intake (Phase 1.2)** - the most common reason for "the installer doesn't do what I want" after 2 weeks.
+13. **Identifying the installer engine from a lone string match, then never running it**. A coincidental `nsis`
+    substring made an install4j installer look like NSIS -> `/S` hung on the language dialog. Confirm the engine by
+    its definitive fingerprint (Appendix L.1) AND behaviorally verify the silent switch (run it once, timeout+kill,
+    expect exit 0 with no dialog) before packaging.
+14. **A trademark sign breaking a DisplayName filter** - `-match 'Name'` misses `Name(R)`, so uninstall finds
+    nothing and silently no-ops. Use a tolerant regex (Appendix L.3).
+15. **Shipping a driver/cert as a note instead of a deliverable**. If the installer stages a driver via dpinst,
+    extract the signer `.cer`, bundle it, and import it to TrustedPublisher in Pre-Install (Appendix N) - don't
+    just mention it in the dossier.
 
 ---
 
@@ -1528,11 +1537,26 @@ the natural detection rule.
 - File metadata/strings: `(Get-Item setup.exe).VersionInfo`; a `strings`-style scan for marker text.
 - **Inno Setup:** EXE contains `Inno Setup` / `JR.Inno.Setup`; uninstaller `unins000.exe`.
 - **NSIS:** EXE contains `Nullsoft.NSIS` / `NullsoftInst`; uninstaller `Uninstall.exe` / `uninst.exe`.
-- **InstallShield:** `setup.exe` + `*.cab` / `data1.hdr` / `0x0409.ini`; strings `InstallShield`.
+- **InstallShield:** `setup.exe` + `*.cab` / `data1.hdr` / `0x0409.ini`; strings `InstallShield` / `ISSetupStream`;
+  `ISInternalDescription "Setup Launcher"`. Basic-MSI vs InstallScript: extract (7-Zip) - an embedded `.msi`
+  + `Windows Installer` strings => Basic MSI; `data1.cab`/`setup.inx`/`_isres*` => InstallScript.
+- **install4j (Java):** EXE strings `com/install4j/runtime` / `exe4j` / `i4jparams.conf` / `-Duser.language`;
+  extracts an `e4j*.tmp_dir*` with a bundled `jre\` + `i4jparams.conf` (XML: `install4jVersion`, screens/actions).
+  Uninstaller is `<installdir>\uninstall.exe`. **`/S` is NOT its switch** - passing `/S` shows the
+  language-selection dialog and hangs; the unattended switch is **`-q`**, and it needs elevation (a
+  `RequestPrivilegesAction`) or it stalls waiting for it.
 - **WiX Burn bundle:** EXE strings `WixBundle` / `.wixburn`; has a `BundleProviderKey`.
 - **MSI:** a `.msi` (or an EXE that strings-shows `Windows Installer` / extracts an MSI).
 - **Squirrel:** `Update.exe` + `*.nupkg`; per-user `%LocalAppData%\<App>`.
 - **MSIX/AppX:** `.msix` / `.appx` / `.msixbundle`.
+
+> **A single string match is a HINT, not proof (BINDING).** A coincidental substring (e.g. `nsis` inside an
+> unrelated blob) can misidentify the framework - a real case: an install4j Aperio installer was mistaken for
+> NSIS, so `/S` was used, which hung on the language dialog forever. Confirm the framework by its *definitive*
+> fingerprint (install4j -> `i4jparams.conf`; InstallShield Basic MSI -> `ISSetupStream` + embedded MSI), and
+> then **behaviorally verify the silent switch**: run `installer <switch>` once with a timeout + a window/exit
+> watch (kill on timeout) and confirm it exits 0 with no dialog BEFORE building the package. "Runs infinitely"
+> or "a dialog appears under /S" means the switch is wrong for that engine - do not ship it untested.
 
 ### L.2 Switch reference
 | Tech | Silent install | Silent uninstall | No reboot | Log | Detect | Notes |
@@ -1546,7 +1570,8 @@ the natural detection rule.
 | **WiX Burn bundle** | `bundle.exe /quiet /norestart` | `bundle.exe /uninstall /quiet` | `/norestart` | `/log "log"` | registry (BundleProviderKey) / file version | wraps MSIs; a single ProductCode is unreliable |
 | **Squirrel (Electron)** | `Setup.exe --silent` | `%LocalAppData%\<App>\Update.exe --uninstall -s` | n/a | n/a | file version under `%LocalAppData%` | usually PER-USER; a System/Win32 install needs care |
 | **MSIX / AppX** | provisioning (`Add-AppxProvisionedPackage`) | `Remove-AppxPackage` | n/a | n/a | package name / version | different model; not a classic Win32 installer |
-| **install4j / IzPack (Java)** | `installer.exe -q -overwrite` / `-options resp.txt` | uninstaller `-q` | n/a | `-Dinstall4j.logToStderr=true` | registry / file | response-file driven |
+| **install4j (Java)** | `installer.exe -q` (unattended) | `<installdir>\uninstall.exe -q` | n/a | `-Dinstall4j.logToStderr=true` | registry / file version | **NOT `/S`** (that shows the language dialog + hangs). Needs elevation (runs as SYSTEM under Intune). QuietUninstallString is often EMPTY -> pass `-q` via `-AdditionalArgumentList`. Bundles its own JRE (no external dep). May `dpinst`-install drivers - extract the signer `.cer` and pre-trust it (TrustedPublisher). |
+| **IzPack (Java)** | `installer.jar auto-install.xml` / `-options resp.txt` | uninstaller `-q` | n/a | varies | registry / file | response-file driven |
 | **InstallAware / Wise** | `/s` or `/silent` | vendor-specific | varies | varies | registry / file | confirm per build; often MSI underneath |
 
 ### L.3 Detection-rule choice
@@ -1554,6 +1579,12 @@ the natural detection rule.
 - EXE / other -> a **PowerShell detection script** (file version / registry value), OR an Intune **file/registry
   version rule**. Never mix a script rule and a file/registry rule for the same app.
 - Per-user installers (Squirrel) detect under `%LocalAppData%` - run detection in the right context.
+
+> **Trademark-sign gotcha in DisplayName filters.** ARP `DisplayName` / `Publisher` often carry a `(R)`/`(TM)`
+> sign (e.g. `Aperio(R) Programming Application`, `ASSA ABLOY(R)`). A literal `-match 'Aperio Programming
+> Application'` then FAILS (the sign sits between the words), so `Uninstall-ADTApplication` / `Get-ADTApplication`
+> find nothing, report success, and remove nothing. Use a tolerant regex - `-match 'Aperio.*Programming
+> Application'` - and apply the same in the detection script's registry match.
 
 ---
 


### PR DESCRIPTION
## Was
Ergaenzt den Deployment-Guide + Changelog um eine real erlebte Lektion beim Paketieren der ASSA ABLOY Aperio Programming Application.

- **L.1**: install4j-Fingerprint (`com/install4j/runtime`, `exe4j`, `i4jparams.conf`, gebuendeltes `jre\`); `/S` ist NICHT der Switch (haengt im Sprachdialog) - korrekt ist `-q` mit Elevation. Schaerferer InstallShield-Fingerprint.
- **L.1 (BINDING)**: Ein einzelner String-Treffer ist ein Hinweis, kein Beweis - Engine ueber den definitiven Fingerprint bestaetigen UND den Silent-Switch verhaltensmaessig verifizieren (einmal mit Timeout+Kill laufen lassen, Exit 0 ohne Dialog) VOR dem Packen.
- **L.2**: install4j-Zeile korrigiert (`-q`, Elevation, leere QuietUninstallString -> `-q` anhaengen, gebuendeltes JRE, dpinst-Treiber-Cert vorab trusten). IzPack abgetrennt.
- **L.3**: Trademark-Zeichen-Gotcha in DisplayName-Filtern (`Name(R)` bricht `-match 'Name'`).
- **Appendix B**: Anti-Patterns 13-15.
- **CHANGELOG.md + README**: 0.17.0-Eintrag (README zieht das fehlende 0.16.0 nach).

## Warum
Ein `nsis`-Zufallstreffer liess einen install4j-Installer wie NSIS aussehen; `/S` hing endlos im Sprachdialog. Diese Regeln verhindern den Fehler kuenftig.

## Verifikation (writing-skills GREEN)
Ein Subagent, der nur den neuen Guide-Text + dieselben irrefuehrenden Hinweise bekam, identifizierte korrekt install4j, waehlte `-q`, verlangte die Verhaltens-Verifikation und wies die "nsis -> /S"-These zurueck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)