### PR TITLE
0.27.1: the dossier described a package that did not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.27.1 - 2026-09-10 - The dossier described a package that did not exist
+
+### Fixed
+- **`New-PsadtReport.ps1` invented facts about the package when they were not supplied, and printed
+  them as statements.** Found while packaging two real apps to test 0.27.0. A dossier generated
+  without `-Metadata` claimed, in the document an approver reads before shipping:
+  - **`_Beschreibung folgt._`** as the Company-Portal app description. That text is copied into
+    Intune verbatim. It is not an empty state - it reads like a finished sentence, survives review
+    and ships to every device in the assignment.
+  - **`Start-ADTMsiProcess`, `Remove-ADTApplication`, "Nutzerdaten bleiben erhalten"** as the hook
+    contents, and a four-cmdlet list, for whatever package was being reported on. A WinMerge package
+    driven by `Start-ADTProcess` with Inno Setup switches was described as calling
+    `Start-ADTMsiProcess` four times. Nothing marked the list as a guess.
+
+  The file already stated the correct rule for itself - *"Default = NOT RUN (neutral) - same honesty
+  rule as pre-flight: no synthetic Success rows"* - and the identity guard already refused with *"a
+  dossier without a real app identity is a placeholder, not a deliverable"*. The rule simply had not
+  been applied to the fields that describe the package's content.
+
+  Now:
+  - The **hooks and the cmdlet list are read out of the launcher** by AST, per `*-ADTDeployment`
+    function, in source order. No launcher to read means `nicht ermittelbar / not derivable`, not a
+    plausible list. An explicit `-Metadata` value still wins.
+  - A **missing description warns** and renders an unmissable marker, and **refuses outright** when
+    `decisions.upload = true` - the same shape as the existing SYSTEM-test gate. `-AllowMissingDescription`
+    is the deliberate, visible opt-out, like `-AllowDefaultLogo` on the upload script.
+  - The **header status is derived** from the pre-flight and SYSTEM-test evidence instead of
+    defaulting to `Upload-bereit - getestet`. That default was a landmine rather than a live bug: the
+    template does not currently render `{{STATUS_DE}}`, so nobody ever saw a dossier claim "tested"
+    while stating "no SYSTEM-test results supplied (no evidence)" three sections lower. It would have
+    gone live the moment the token was wired up.
+
+- **`SKILL.md` Phase 8 did not say the description was mandatory.** It said "App description =
+  Markdown, dossier language, real umlauts" - a formatting rule for a field it never said had to be
+  supplied. It now says the report refuses without it, and that the hooks and cmdlets are derived
+  rather than authored.
+
+### Notes
+- Suite 474 -> 484. The new cases assert the absence of each invented value, that the derived cmdlet
+  list matches a launcher that calls `Start-ADTProcess` and not `Start-ADTMsiProcess`, and that the
+  upload path refuses and writes no file.
+- One pre-existing test needed a description added: an upload now has to clear two gates, not one.
+
 ## 0.27.0 - 2026-09-10 - Half the control plane was gone after the first compaction
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -428,6 +428,22 @@ pre-flight fails on non-ASCII without a BOM), and anything that lands in a packa
 Recent releases below; the complete history is in **[CHANGELOG.md](CHANGELOG.md)** (nothing is ever removed
 from either).
 
+### 0.27.1 - 10.09.2026
+- **Fixed: das Dossier erfand Fakten über das Paket und druckte sie als Aussage.** Beim Paketieren zweier
+  echter Apps zum Test von 0.27.0 aufgefallen. Ohne `-Metadata` behauptete der Report `_Beschreibung folgt._`
+  als Company-Portal-Text — der wird unverändert nach Intune übernommen und liest sich wie ein fertiges Feld —
+  sowie `Start-ADTMsiProcess` und „Nutzerdaten bleiben erhalten" als Hook-Inhalt, für welches Paket auch immer
+  gerade berichtet wurde. Ein WinMerge-Paket, das ausschließlich `Start-ADTProcess` mit Inno-Switches aufruft,
+  wurde so viermal mit einem Cmdlet beschrieben, das es nie verwendet. Nichts kennzeichnete das als Vermutung.
+- **Hooks und Cmdlet-Liste werden jetzt per AST aus dem echten Launcher gelesen**, je `*-ADTDeployment`-Funktion.
+  Kein Launcher vorhanden: „nicht ermittelbar" statt einer plausiblen Liste. Ein explizites `-Metadata` gewinnt
+  weiterhin.
+- **Eine fehlende Beschreibung warnt und wird sichtbar markiert — und wird bei `decisions.upload = true`
+  verweigert**, in derselben Form wie das bestehende SYSTEM-Test-Gate. `-AllowMissingDescription` ist der
+  bewusste, sichtbare Ausweg.
+- **Der Header-Status wird aus den Belegen abgeleitet** statt auf „Upload-bereit · getestet" zu defaulten.
+- **SKILL.md Phase 8** sagt jetzt, dass die Beschreibung Pflicht ist; vorher stand dort nur, wie sie zu
+  formatieren wäre. Suite 474 → 484.
 ### 0.27.0 - 10.09.2026
 - **Fixed: after auto-compaction, half of SKILL.md was gone.** Claude Code re-attaches only the **first
   5000 tokens** of an invoked skill after a summary. SKILL.md was ~10 10900, so the cut fell at line 198 — the

--- a/SKILL.md
+++ b/SKILL.md
@@ -243,9 +243,13 @@ Return codes come from `scripts/Get-PsadtReturnCodes.ps1` - the SINGLE source of
 Intune accepts exactly `success`, `softReboot`, `hardReboot`, `retry`, `failed`; **there is no "Ignored"**, and an
 invalid type THROWS rather than rendering. Pass only the INSTALLER-SPECIFIC codes as
 `@{ Code; Type; De; En }` - they merge over the mandatory `0, 1707, 3010, 1641, 1618, 60001, 60008` table, never
-replace it. Record them once as `research.returnCodes` in the manifest and dossier + upload both pick them up. App description = Markdown, dossier language, real umlauts (structure/template:
-guide F.2). Logo fetch + verify + MSI-icon fallback: guide Appendix J. WinGet dossier additions
-(WinGet >= 1.7.10582 requirement, registry/file detection note): guide Appendix I.6.
+replace it. Record them once as `research.returnCodes` in the manifest and dossier + upload both pick them up.
+**Pass `-Metadata` with the app description.** `DescMdDe`/`DescMdEn` are Markdown, in the dossier language,
+with real umlauts, and that text is copied into Company Portal verbatim - the report REFUSES to render
+without it when `decisions.upload = true`, and marks it as missing otherwise. It is not a field the
+generator can invent for you; nor are the hooks and cmdlet list, which it reads out of the launcher.
+Structure: App. F.2, keys: F.0. Logo fetch + verify + MSI-icon fallback: App. J. WinGet dossier
+additions (WinGet >= 1.7.10582 requirement, registry/file detection note): App. I.6.
 
 <!-- rule:upload-dry-run-first -->
 **Phase 9 - Direct Graph upload (opt-in).** Gate 4. ALWAYS dry-run first (read-only) → show summary +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psadt-deploy-skill",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Installer for the psadt-deploy Claude Code skill: build, test and deploy PSADT v4.x Intune Win32 packages.",
   "keywords": [
     "psadt",

--- a/scripts/New-PsadtReport.ps1
+++ b/scripts/New-PsadtReport.ps1
@@ -61,6 +61,10 @@ param(
 
     [string]$LogoPath,
 
+    # Render an explicit "not supplied" marker in place of the app description instead of refusing.
+    # Deliberate and visible, the way -AllowDefaultLogo is on the upload script - never the default.
+    [switch]$AllowMissingDescription,
+
     [switch]$PassThru
 )
 
@@ -111,6 +115,19 @@ if ($ManifestPath) {
     # the manifest, so the gate can be enforced here instead of relying on the operator remembering it.
     if ($mf.decisions.upload -eq $true -and -not $Metadata.ContainsKey('SystemTest')) {
         throw "decisions.upload is true but no SYSTEM-test result was supplied. Run Invoke-PsadtSystemTest.ps1 (Install + Uninstall) first - Phase 6 is the binding gate for upload - or set decisions.upload to false."
+    }
+
+    # The Company-Portal description is the one field in this document an end user reads, and it is
+    # copied out of here by hand. A default of "_Beschreibung folgt._" is not a neutral empty state:
+    # it renders as a finished sentence, survives review, and ships to every device in the assignment.
+    # Same rule as the identity floor above - do not invent a value that looks supplied.
+    $hasDesc = ($Metadata.ContainsKey('DescMdDe') -and -not [string]::IsNullOrWhiteSpace([string]$Metadata['DescMdDe'])) -or
+               ($Metadata.ContainsKey('DescMdEn') -and -not [string]::IsNullOrWhiteSpace([string]$Metadata['DescMdEn']))
+    if (-not $hasDesc -and -not $AllowMissingDescription) {
+        if ($mf.decisions.upload -eq $true) {
+            throw "No app description was supplied (DescMdDe / DescMdEn) and decisions.upload is true. That text goes to Company Portal verbatim - write it, or pass -AllowMissingDescription to render an explicit 'not supplied' marker instead."
+        }
+        Write-Warning "No app description supplied (DescMdDe / DescMdEn). The dossier will show an explicit 'not supplied' marker rather than placeholder prose. Fill it before any upload."
     }
 }
 
@@ -203,8 +220,10 @@ $moduleVersion = Get-Val 'ModuleVersion' $psadtVersion
 
 $subDe   = Get-Val 'SubDe' "Intune Win32 &middot; PSADT v$psadtVersion Paket-Report"
 $subEn   = Get-Val 'SubEn' "Intune Win32 &middot; PSADT v$psadtVersion package report"
-$statusDe = Get-Val 'StatusDe' 'Upload-bereit &middot; getestet'
-$statusEn = Get-Val 'StatusEn' 'Ready to upload &middot; tested'
+# $statusDe / $statusEn are DERIVED further down, once the pre-flight and SYSTEM-test evidence has
+# actually been read. They used to default to "Upload-bereit / Ready to upload - tested", which this
+# document then contradicted three sections later with "no SYSTEM-test results supplied (no evidence)".
+# The header is the line people read; a claim there has to come from the evidence, not from a literal.
 
 # ----------------------------------------------------------------------------- app-info cells
 $cat = Get-Val 'Category' $null
@@ -345,8 +364,11 @@ $vLocation = $loc = Get-Val 'Location' ''
 $vLocation = if ($loc) { Codei $loc } else { Bspan 'Output-Ordner der App' 'app output folder' }
 
 # ----------------------------------------------------------------------------- description markdown
-$descMdDe = Esc (Get-Val 'DescMdDe' "**$appName $appVersion**`n`n_Beschreibung folgt._")
-$descMdEn = Esc (Get-Val 'DescMdEn' "**$appName $appVersion**`n`n_Description to follow._")
+# No invented prose. "_Beschreibung folgt._" read like a finished field, survived review and shipped
+# to Company Portal; this marker cannot be mistaken for content. The guard above refuses outright when
+# an upload is planned.
+$descMdDe = Esc (Get-Val 'DescMdDe' "**$appName $appVersion**`n`n> **KEINE BESCHREIBUNG HINTERLEGT.** Dieses Feld wird unveraendert ins Company Portal uebernommen und muss vor dem Upload gefuellt werden (New-PsadtReport.ps1 -Metadata @{ DescMdDe = '...' }).")
+$descMdEn = Esc (Get-Val 'DescMdEn' "**$appName $appVersion**`n`n> **NO DESCRIPTION SUPPLIED.** This field is copied to Company Portal verbatim and must be filled before upload (New-PsadtReport.ps1 -Metadata @{ DescMdEn = '...' }).")
 
 # ----------------------------------------------------------------------------- return codes
 # One source of truth, shared with Invoke-IntuneWin32Upload.ps1 - see Get-PsadtReturnCodes.ps1. Two
@@ -397,23 +419,46 @@ function Format-HookItems {
         else { "              <li>$(Esc ([string]$it))</li>" }
     }) -join "`n"
 }
-$hookInstall = Format-HookItems (Get-Val 'HookInstall' @(
-    'Show-ADTInstallationWelcome (CloseProcesses, CheckDiskSpace)',
-    'Start-ADTMsiProcess / Start-ADTProcess (silent)',
-    @{ De = 'Startmen&uuml;-Verkn&uuml;pfung (kein Desktop)'; En = 'Start-menu shortcut (no desktop)' }
-))
-$hookUninstall = Format-HookItems (Get-Val 'HookUninstall' @(
-    'Start-ADTMsiProcess -Action Uninstall / Remove-ADTApplication',
-    @{ De = 'App-spezifische Leftovers entfernen'; En = 'Remove app-specific leftovers' },
-    @{ De = 'Nutzerdaten bleiben erhalten'; En = 'User data is preserved' }
-))
-$hookRepair = Format-HookItems (Get-Val 'HookRepair' @(
-    'Start-ADTMsiProcess -Action Repair (/fa) oder Reinstall',
-    @{ De = 'Dateien + Verkn&uuml;pfungen werden neu gesetzt'; En = 'Files + shortcuts are re-applied' }
-))
+# The hooks and the cmdlet list describe THIS package, so they are read out of THIS package. The
+# defaults here used to be a generic MSI package's contents - "Start-ADTMsiProcess", "user data is
+# preserved" - printed as fact for whatever was being reported on. A WinMerge package driven by
+# Start-ADTProcess with Inno switches was described as calling Start-ADTMsiProcess four times.
+# Nothing in the document said the list was a guess.
+$launcherAst = $null
+if ($ManifestPath) {
+    $launcherFile = Join-Path (Split-Path -Parent (Resolve-Path -LiteralPath $ManifestPath).Path) 'Invoke-AppDeployToolkit.ps1'
+    if (Test-Path -LiteralPath $launcherFile) {
+        $launcherAst = [System.Management.Automation.Language.Parser]::ParseFile($launcherFile, [ref]$null, [ref]$null)
+    }
+}
+
+function Get-HookCommands {
+    # ADT commands actually invoked inside one *-ADTDeployment function, in source order, deduplicated.
+    param($Ast, [string]$FunctionName)
+    if (-not $Ast) { return $null }
+    $fn = $Ast.FindAll({ param($n)
+        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $FunctionName }, $true) |
+        Select-Object -First 1
+    if (-not $fn) { return $null }
+    $names = $fn.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+        ForEach-Object { $_.GetCommandName() } |
+        Where-Object { $_ -and $_ -match '^[A-Za-z]+-(ADT|Psadt)' }
+    return @($names | Select-Object -Unique)
+}
+
+$hookInstallCmds   = Get-HookCommands $launcherAst 'Install-ADTDeployment'
+$hookUninstallCmds = Get-HookCommands $launcherAst 'Uninstall-ADTDeployment'
+$hookRepairCmds    = Get-HookCommands $launcherAst 'Repair-ADTDeployment'
+
+$notDerived = @(@{ De = '&ndash; nicht ermittelbar (kein Launcher gefunden), nicht &uuml;bergeben'; En = '&ndash; not derivable (no launcher found), not supplied' })
+
+$hookInstall   = Format-HookItems (Get-Val 'HookInstall'   $(if ($hookInstallCmds)   { $hookInstallCmds }   else { $notDerived }))
+$hookUninstall = Format-HookItems (Get-Val 'HookUninstall' $(if ($hookUninstallCmds) { $hookUninstallCmds } else { $notDerived }))
+$hookRepair    = Format-HookItems (Get-Val 'HookRepair'    $(if ($hookRepairCmds)    { $hookRepairCmds }    else { $notDerived }))
 
 # ----------------------------------------------------------------------------- cmdlets
-$cmds = Get-Val 'Cmdlets' @('Show-ADTInstallationWelcome', 'Start-ADTMsiProcess', 'Write-ADTLogEntry', 'Close-ADTSession')
+$derivedCmds = @($hookInstallCmds + $hookUninstallCmds + $hookRepairCmds | Where-Object { $_ } | Select-Object -Unique | Sort-Object)
+$cmds = Get-Val 'Cmdlets' $(if ($derivedCmds) { $derivedCmds } else { @('nicht ermittelbar / not derivable') })
 $cmdChips = @(foreach ($c in $cmds) { "          <span class=`"chip`">$(Esc $c)</span>" }) -join "`n"
 
 # ----------------------------------------------------------------------------- pre-flight
@@ -450,6 +495,36 @@ $stRows = @(foreach ($s in $st) {
 }) -join "`n"
 $stNoteDe = Get-Val 'SystemTestNoteDe' 'Keine SYSTEM-Test-Ergebnisse &uuml;bergeben &ndash; der SYSTEM-Test wurde nicht ausgef&uuml;hrt (kein Beleg).'
 $stNoteEn = Get-Val 'SystemTestNoteEn' 'No SYSTEM-test results supplied &ndash; the SYSTEM test was not run (no evidence).'
+
+# ----------------------------------------------------------------------------- header status
+# Derived, never asserted. The rule the SYSTEM-test table and the pre-flight KPI already follow -
+# "no synthetic Success rows" - applies with most force to the badge at the top of the page, because
+# that is the line an approver reads before deciding to ship. An explicit StatusDe/StatusEn in
+# -Metadata still wins; what is gone is the default that claimed "tested" with nothing behind it.
+$stWasRun = @($st | Where-Object { [string]$_.Result -ne 'not run' }).Count -gt 0
+$stFailed = @($st | Where-Object { $_.Cls -eq 'b-fail' }).Count -gt 0
+if ($pfHasFail) {
+    $statusDefaultDe = 'Nicht upload-bereit &middot; Pre-flight ROT'
+    $statusDefaultEn = 'Not ready to upload &middot; pre-flight RED'
+}
+elseif ($stFailed) {
+    $statusDefaultDe = 'Nicht upload-bereit &middot; SYSTEM-Test fehlgeschlagen'
+    $statusDefaultEn = 'Not ready to upload &middot; SYSTEM test failed'
+}
+elseif (-not $stWasRun) {
+    $statusDefaultDe = 'Nicht getestet &middot; kein SYSTEM-Test'
+    $statusDefaultEn = 'Not tested &middot; no SYSTEM test'
+}
+elseif ($pfAllNeut) {
+    $statusDefaultDe = 'Getestet &middot; Pre-flight nicht ausgef&uuml;hrt'
+    $statusDefaultEn = 'Tested &middot; pre-flight not run'
+}
+else {
+    $statusDefaultDe = 'Upload-bereit &middot; getestet'
+    $statusDefaultEn = 'Ready to upload &middot; tested'
+}
+$statusDe = Get-Val 'StatusDe' $statusDefaultDe
+$statusEn = Get-Val 'StatusEn' $statusDefaultEn
 
 # ----------------------------------------------------------------------------- token map
 $logoSrc = Get-LogoDataUri -Path $LogoPath -AppName $appName

--- a/tests/New-PsadtReport.Tests.ps1
+++ b/tests/New-PsadtReport.Tests.ps1
@@ -198,7 +198,9 @@ Describe 'New-PsadtReport -ManifestPath (0.21.0)' {
         $m.decisions = @{ upload = $true }
         & $script:writeMf $m
         $st = @(@{ StepDe = 'Install'; StepEn = 'Install'; Exit = '0'; Detection = 'installed'; Cls = 'b-ok'; Result = 'OK' })
-        { & $script:gen -ManifestPath $script:mfPath -Metadata @{ SystemTest = $st } -OutputPath $script:outHtml } | Should -Not -Throw
+        # A description is supplied too, because an upload has to clear BOTH gates since 0.27.1. This
+        # test is about the SYSTEM-test gate; the description gate has its own tests further down.
+        { & $script:gen -ManifestPath $script:mfPath -Metadata @{ SystemTest = $st; DescMdDe = '**Test**'; DescMdEn = '**Test**' } -OutputPath $script:outHtml } | Should -Not -Throw
     }
 
     It 'throws for a manifest path that does not exist' {
@@ -323,5 +325,131 @@ Describe 'Return codes in the rendered dossier' {
         $html = Get-Content $script:rcOut -Raw
         $html | Should -Match '<tr data-rc-type="softReboot">'
         $html | Should -Not -Match 'rc-token'
+    }
+}
+
+
+Describe 'The dossier never invents a fact about the package (0.27.1)' {
+    # SCOPE NOTE: the failure this guards against shipped. A dossier generated without -Metadata
+    # described a generic MSI package: the Company-Portal text read "_Beschreibung folgt._", the hook
+    # lists claimed Start-ADTMsiProcess and "user data is preserved", and the cmdlet list named four
+    # cmdlets nobody had checked. For a WinMerge package driven by Start-ADTProcess with Inno
+    # switches, that was four printed occurrences of a cmdlet the package never calls.
+    #
+    # None of it was marked as a guess. The document exists so an approver can decide whether to
+    # ship; a plausible invention there is worse than a blank, because a blank gets filled.
+
+    BeforeEach {
+        $script:pkg = Join-Path ([System.IO.Path]::GetTempPath()) ("psadtpkg_" + [guid]::NewGuid().ToString('N'))
+        New-Item $script:pkg -ItemType Directory -Force | Out-Null
+        $script:manifest = Join-Path $script:pkg 'psadt-package.json'
+        @{
+            schema = 1
+            app = @{ vendor = 'ACME'; name = 'Widget'; version = '1.0'; arch = 'x64'; lang = 'EN'; revision = 1 }
+            decisions = @{ upload = $false }
+        } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $script:manifest -Encoding UTF8
+    }
+
+    AfterEach {
+        if (Test-Path $script:pkg) { Remove-Item $script:pkg -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    Context 'the app description' {
+        It 'never renders invented prose in place of a missing description' {
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningAction SilentlyContinue
+            $html = Get-Content $script:out -Raw
+            $html | Should -Not -Match 'Beschreibung folgt'
+            $html | Should -Not -Match 'Description to follow'
+        }
+
+        It 'says plainly that no description was supplied' {
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningAction SilentlyContinue
+            $html = Get-Content $script:out -Raw
+            $html | Should -Match 'KEINE BESCHREIBUNG HINTERLEGT'
+        }
+
+        It 'warns when the description is missing' {
+            $warnings = @()
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningVariable warnings -WarningAction SilentlyContinue
+            ($warnings -join ' ') | Should -Match 'description'
+        }
+
+        It 'REFUSES outright when an upload is planned and writes no file' {
+            # An earlier It in this Context wrote to the same path; the assertion below is about THIS
+            # run producing nothing, so start from a known-absent file.
+            if (Test-Path $script:out) { Remove-Item $script:out -Force }
+            @{
+                schema = 1
+                app = @{ vendor = 'ACME'; name = 'Widget'; version = '1.0'; arch = 'x64'; lang = 'EN'; revision = 1 }
+                decisions = @{ upload = $true }
+            } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $script:manifest -Encoding UTF8
+            { & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -Metadata @{
+                SystemTest = @(@{ StepDe = 'Install'; StepEn = 'Install'; Exit = '0'; Detection = 'ok'; Cls = 'b-ok'; Result = 'pass' })
+            } } | Should -Throw -ExpectedMessage '*description*'
+            Test-Path $script:out | Should -BeFalse
+        }
+
+        It 'accepts -AllowMissingDescription as a deliberate, visible choice' {
+            { & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -AllowMissingDescription } | Should -Not -Throw
+            (Get-Content $script:out -Raw) | Should -Match 'KEINE BESCHREIBUNG HINTERLEGT'
+        }
+    }
+
+    Context 'the hooks and the cmdlet list' {
+        BeforeEach {
+            # A launcher that calls Start-ADTProcess and NOT Start-ADTMsiProcess - the exact shape the
+            # old defaults got wrong.
+            @'
+$adtSession = @{ AppName = 'Widget' }
+function Install-ADTDeployment {
+    Show-ADTInstallationWelcome -CloseProcesses 'widget'
+    Start-ADTProcess -FilePath 'setup.exe' -ArgumentList '/VERYSILENT'
+}
+function Uninstall-ADTDeployment {
+    Start-ADTProcess -FilePath 'unins000.exe' -ArgumentList '/VERYSILENT'
+}
+function Repair-ADTDeployment {
+    Start-ADTProcess -FilePath 'setup.exe' -ArgumentList '/VERYSILENT'
+}
+'@ | Set-Content -LiteralPath (Join-Path $script:pkg 'Invoke-AppDeployToolkit.ps1') -Encoding UTF8
+        }
+
+        It 'reports the cmdlets the launcher actually calls, not a generic MSI list' {
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningAction SilentlyContinue
+            $html = Get-Content $script:out -Raw
+            $html | Should -Match 'Start-ADTProcess'
+            $html | Should -Not -Match 'Start-ADTMsiProcess'
+        }
+
+        It 'does not assert uninstall behaviour nobody stated' {
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningAction SilentlyContinue
+            $html = Get-Content $script:out -Raw
+            $html | Should -Not -Match 'Nutzerdaten bleiben erhalten'
+            $html | Should -Not -Match 'User data is preserved'
+        }
+
+        It 'says "not derivable" when there is no launcher to read' {
+            Remove-Item (Join-Path $script:pkg 'Invoke-AppDeployToolkit.ps1') -Force
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningAction SilentlyContinue
+            (Get-Content $script:out -Raw) | Should -Match 'nicht ermittelbar'
+        }
+
+        It 'still lets an explicit -Metadata value win' {
+            & $script:gen -ManifestPath $script:manifest -OutputPath $script:out -WarningAction SilentlyContinue -Metadata @{
+                Cmdlets = @('Get-ADTApplication')
+            }
+            (Get-Content $script:out -Raw) | Should -Match 'Get-ADTApplication'
+        }
+    }
+
+    Context 'the header status' {
+        It 'is derived from the evidence rather than claiming "tested" by default' {
+            # The literal default used to say "Upload-bereit - getestet" while the same document said
+            # "no SYSTEM-test results supplied (no evidence)" three sections lower. The template does
+            # not currently render this token, which is why nobody saw it - a landmine, not a bug yet.
+            $src = Get-Content (Join-Path $PSScriptRoot '..\scripts\New-PsadtReport.ps1') -Raw
+            $src | Should -Not -Match "Get-Val 'StatusDe' 'Upload-bereit"
+            $src | Should -Match '\$statusDefaultDe'
+        }
     }
 }


### PR DESCRIPTION
0.27.1: the dossier described a package that did not exist

Found by using the skill rather than by reading it - packaging two real apps
to test 0.27.0.

New-PsadtReport.ps1 filled unsupplied facts with confident-looking values and
printed them as statements, in the one document an approver reads before
deciding to ship:

- "_Beschreibung folgt._" as the Company-Portal description. That string is
  copied into Intune verbatim. It is not an empty state; it reads like a
  finished sentence, survives review, and reaches every device in the
  assignment.
- "Start-ADTMsiProcess", "Remove-ADTApplication" and "Nutzerdaten bleiben
  erhalten" as the hook contents, plus a four-cmdlet list, for whatever
  package was being reported on. A WinMerge package driven entirely by
  Start-ADTProcess with Inno Setup switches was described as calling
  Start-ADTMsiProcess four times. Nothing marked any of it as a guess.

The file already knew the rule. It says so about itself - "Default = NOT RUN
(neutral) - same honesty rule as pre-flight: no synthetic Success rows" - and
the identity guard already refuses with "a dossier without a real app identity
is a placeholder, not a deliverable". The rule had simply never been applied
to the fields that describe the package's content.

Now the hooks and the cmdlet list are read out of the launcher by AST, per
*-ADTDeployment function. No launcher means "nicht ermittelbar", not a
plausible list. A missing description warns and renders an unmissable marker,
and refuses outright when decisions.upload is true - the same shape as the
SYSTEM-test gate, with -AllowMissingDescription as the deliberate opt-out.

The header status is now derived from the pre-flight and SYSTEM-test evidence
instead of defaulting to "Upload-bereit - getestet". That one was a landmine
rather than a live bug: the template does not render {{STATUS_DE}}, so no
dossier ever actually claimed "tested" while stating "no SYSTEM-test results
supplied (no evidence)" three sections lower. It would have, the moment anyone
wired the token up.

SKILL.md Phase 8 said "App description = Markdown, dossier language, real
umlauts" - a formatting rule for a field it never said had to be supplied. It
now says the report refuses without it.

Suite 474 -> 484. One pre-existing test needed a description added: an upload
clears two gates now, not one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
