### PR TITLE
0.28.0: the sandbox booted without its mapped folders and said nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.28.0 - 2026-09-11 - The sandbox booted without its mapped folders and said nothing
+
+Ported from [#17](https://github.com/pt1987/claude-code-psadt-skill/pull/17) by @CSN-TechX, found while
+packaging real apps for Intune. The branch predated the 0.27.0 reference split, so the documentation half
+landed in `references/appendix-l-installers.md` rather than the guide file it was written against.
+
+### Fixed
+- **A space anywhere in the `.wsb` path silently disabled every custom mapped folder.**
+  `Start-Process -ArgumentList $wsbPath` does not quote its elements, so the path was split across
+  several argv entries and `WindowsSandbox.exe` booted with the built-in shares only - no error, no
+  warning, just a guest that could not see the package. A Windows username with a space in it is enough
+  to trigger it, and it puts a space in `%LOCALAPPDATA%` too, which is where the work folder lives. The
+  symptom reads exactly like an upstream Sandbox bug, which is how it survived this long.
+- **`<LogonCommand>` never ran at all on the affected Sandbox app version**
+  ([microsoft/Windows-Sandbox#125](https://github.com/microsoft/Windows-Sandbox/issues/125)) - the
+  process is not spawned, while `MappedFolders` keeps working. The work folder is now mapped straight
+  onto the guest's Startup folder, which Windows' own logon path populates, and a one-line
+  `StartupTrigger.cmd` starts the runner. The runner `.ps1` sits in a `runner\` subfolder: Startup
+  auto-executes only `.exe/.bat/.cmd/.lnk/.vbs`, and a bare `.ps1` loose in there additionally makes
+  Explorer raise its own "how do you want to open this file" prompt.
+- **A transient read could report a real result as empty.** The action's `.cmd` writes the output file
+  and the exit-code file on consecutive lines, but the bytes of the first are not guaranteed visible to
+  the reading process the moment the second is - Defender briefly locking a fresh file is enough. A
+  detection step captured `stdout: ""` and was read as "not detected", while the same file re-read at
+  the end of the run held the real answer. The read now retries, which separates a genuinely empty
+  result (the normal case for an absent app) from an unreadable one.
+
+### Changed
+- **`schtasks` failures are no longer invisible.** Neither the `/Create` nor the `/Run` call checked its
+  exit code, so any failure to create or start the SYSTEM task presented as the action timing out 900
+  seconds later - the one symptom that says nothing about the cause. Both are checked and the real
+  message is raised.
+- **The runner verifies it is elevated before the first action.** `schtasks /RU SYSTEM /RL HIGHEST`
+  needs the full administrator token. `<LogonCommand>` supplied one implicitly; an Explorer-launched
+  Startup item does not guarantee it. Without the check, a filtered token would have made all seven
+  actions fail identically and pointed the evidence at the package.
+- **The noisy `/ST` warning is suppressed rather than designed away.** The PR silenced it by moving the
+  trigger to now+1min. That arms a real ONCE trigger - which can re-launch the same deployment `.cmd`
+  as SYSTEM while the action is still running, since `MultipleInstancesPolicy` defaults to `IgnoreNew`
+  and only covers overlap - and `(Get-Date).ToString('HH:mm')` is culture-dependent on top: under fi-FI
+  it renders `15.02`, which `schtasks` rejects with "Invalid start time value", creating no task at all.
+  `00:00` stays, deliberately in the past, and its stderr notice goes to a file.
+- **New `-GuestSettleDelaySeconds`** (default 0), for hosts where the mapped folder is not ready the
+  instant the guest logs on. Implemented with `ping -n` rather than `timeout`, which aborts without a
+  console it owns.
+
+### Added
+- **NSIS MultiUser (`MultiUser.nsh`) is documented as its own trap** (App. L.1 / L.2 / L.7). Built with
+  the MultiUser plugin, a bare `/S` fails `.onInit`'s command-line validation and exits in well under a
+  second, before a single file is written, with no stdout and no stderr at all. The fix is `/allusers`
+  or `/currentuser` alongside `/S`; `/allusers` is the default for a System-context Intune install, and
+  `/currentuser` moves the detection rule into the user profile. The observed exit code is recorded as
+  one data point, not a signature - the reliable tell is the shape: genuine NSIS, sub-second exit, no
+  output, nothing written. It is now a **Gate 2** decision.
+- **An external runtime prerequisite is researched in Phase 2 and decided at Gate 1** (phase 1.4, rule
+  `runtime-prerequisite`). A package can pass every gate GREEN while the installed app is inert, because
+  no phase in this skill ever launches the application: Phase 5 parses it, Phase 6 drives the detection
+  script, Phase 11 watches the delivery. Options: separate package + Intune app dependency
+  (recommended), bundle it, document as manual, or skip - recorded either way.
+- **A manual interactive test is offered after a GREEN Phase 6 verdict** (phase 6.4), situationally -
+  for an unfamiliar app or vendor, anything flagged in 1.4, or the first package of a new app family.
+  GREEN means the package installs, detects, uninstalls, reinstalls and repairs. It does not mean the
+  app works: a missing runtime, a first-run wizard, an absent licence and a broken default config all
+  leave it GREEN.
+
+### Notes
+- Suite 484 -> 493.
+- SKILL.md gained four control-plane decisions and stayed inside the compaction budget by **moving three
+  blocks into the appendices that already own them**, not by shortening anything: the driver decision
+  tree to App. Q.1, the sandbox route detail to phase 6.1, and the per-action loop to phase 6.2 (which
+  never carried it - it existed only in SKILL.md). Phase 6 ends at byte 17 456 of 17 500.
+
 ## 0.27.1 - 2026-09-10 - The dossier described a package that did not exist
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -429,52 +429,38 @@ The two most recent releases are below. **[CHANGELOG.md](CHANGELOG.md)** carries
 every release since 0.1.0, and nothing is ever removed from it - this section is a window onto it, not a
 second copy to keep in sync.
 
-### 0.27.1 - 10.09.2026
-- **Fixed: das Dossier erfand Fakten über das Paket und druckte sie als Aussage.** Beim Paketieren zweier
-  echter Apps zum Test von 0.27.0 aufgefallen. Ohne `-Metadata` behauptete der Report `_Beschreibung folgt._`
-  als Company-Portal-Text — der wird unverändert nach Intune übernommen und liest sich wie ein fertiges Feld —
-  sowie `Start-ADTMsiProcess` und „Nutzerdaten bleiben erhalten" als Hook-Inhalt, für welches Paket auch immer
-  gerade berichtet wurde. Ein WinMerge-Paket, das ausschließlich `Start-ADTProcess` mit Inno-Switches aufruft,
-  wurde so viermal mit einem Cmdlet beschrieben, das es nie verwendet. Nichts kennzeichnete das als Vermutung.
-- **Hooks und Cmdlet-Liste werden jetzt per AST aus dem echten Launcher gelesen**, je `*-ADTDeployment`-Funktion.
-  Kein Launcher vorhanden: „nicht ermittelbar" statt einer plausiblen Liste. Ein explizites `-Metadata` gewinnt
-  weiterhin.
-- **Eine fehlende Beschreibung warnt und wird sichtbar markiert — und wird bei `decisions.upload = true`
-  verweigert**, in derselben Form wie das bestehende SYSTEM-Test-Gate. `-AllowMissingDescription` ist der
-  bewusste, sichtbare Ausweg.
-- **Der Header-Status wird aus den Belegen abgeleitet** statt auf „Upload-bereit · getestet" zu defaulten.
-- **SKILL.md Phase 8** sagt jetzt, dass die Beschreibung Pflicht ist; vorher stand dort nur, wie sie zu
-  formatieren wäre. Suite 474 → 484.
-### 0.27.0 - 10.09.2026
-- **Fixed: after auto-compaction, half of SKILL.md was gone.** Claude Code re-attaches only the **first
-  5000 tokens** of an invoked skill after a summary. SKILL.md was ~10 10900, so the cut fell at line 198 — the
-  middle of Phase 2. In exactly the sessions long enough to compact, the skill lost Phases 3–12, the whole
-  troubleshooting table, every anti-pattern and the reference map. The fix is **ordering, not size**: the
-  operating mode, the four gates, the conventions and Phases 0–6 now sit ahead of the cut, and Phase 6 ends
-  at byte 17 457 of a 17 500-byte budget — with a test that fails if it ever crosses back.
-- **Fixed: `--ref <tag>` returned HTTP 404 on the tarball route.** The installer built
-  `tar.gz/refs/heads/<ref>`, and `refs/heads` only resolves *branches* — so pinning worked with git and failed
-  on exactly the machines without it, which are the ones most likely to need a pinned release.
-  `Update-PsadtSkill.ps1` had the same latent bug in its archive path.
-- **Fixed: a failed install exited 127 instead of 1**, with a libuv assertion after the error message. A
-  mistyped `--ref` printed a correct explanation and then looked like a crash.
-- **Changed: the default install is the newest release tag, not `main`.** This skill registers an Entra app
-  with admin consent and writes to a tenant; installing whatever last landed on a branch is not a defensible
-  default for that. `--ref main` and `--ref v0.27.0` both remain. The update check now distinguishes a
-  release-pinned installation (counts *releases* behind) from one following a branch.
-- **Changed: the 2942-line deployment guide is now nineteen files**, one per domain, with
-  `references/README.md` as the map. Section numbering is unchanged, so every "App. L.1" and "Phase 6.2"
-  still resolves.
-- **Changed (behaviour): Phase 11 no longer re-runs Phase 6.** Phase 6 answers *does the package work* (the
-  gate, in a throwaway Sandbox); Phase 11 answers *does the delivery work* (Intune test group, real device,
-  `AppWorkload.log`). A package that passes 6 and fails 11 now tells you something.
-- **Changed: `"update skill"` is gone from the description** — un-namespaced, it made this skill answer for
-  every other updatable skill on the machine. `"psadt update"` stays.
-- **Added `SECURITY.md`** — the risk surface next to the control that covers each part of it, each naming the
-  file and the test that implement it.
-- **Added: researched content is data, never instructions** (`references/research-trust.md`) — Phase 2
-  researches on the open web and the result runs as SYSTEM. The install4j case generalised.
-- **Added three guards and CI**: rule anchors proving no binding rule was lost in the move, a two-directional
-  doc cross-reference check that also reads `scripts/`, a context-budget test, and the suite on a clean
-  Windows runner for every push. Suite 441 → 474.
-- **Added `evals/`** — 20 trigger and behaviour cases. Not yet run: `claude plugin eval` is in early access.
+### 0.28.0 - 2026-09-11
+- **Fixed: a space in the `.wsb` path silently disabled every custom mapped folder.** `Start-Process
+  -ArgumentList` does not quote its elements, so Windows Sandbox booted with the built-in shares only -
+  no error, no warning. A username with a space in it is enough, and it reads exactly like an upstream
+  Sandbox bug.
+- **Fixed: `<LogonCommand>` never ran** on the affected Sandbox app version
+  ([#125](https://github.com/microsoft/Windows-Sandbox/issues/125)). The work folder is now mapped onto
+  the guest's Startup folder and a trigger `.cmd` starts the runner, which lives one level down because
+  Startup auto-executes only `.exe/.bat/.cmd/.lnk/.vbs`.
+- **Fixed: a transient read reported a real result as empty** - a detection step captured `stdout: ""`
+  while the same file, re-read at the end of the run, held the right answer. The read now retries.
+- **Changed: `schtasks` failures are checked** instead of surfacing as a 900-second timeout, and the
+  runner verifies it is elevated before the first action - a Startup item does not carry the full admin
+  token by construction the way `<LogonCommand>` did.
+- **Added: NSIS MultiUser needs an explicit `/allusers` or `/currentuser`** (App. L.7). A bare `/S`
+  exits in under a second with no output and nothing installed. Now a Gate 2 decision.
+- **Added: an unbundled runtime prerequisite is researched in Phase 2 and decided at Gate 1**, and a
+  manual interactive test is offered after a GREEN Phase 6 - the loop proves the package works, never
+  that the app does. Suite 484 -> 493.
+### 0.27.1 - 2026-09-10
+- **Fixed: the dossier invented facts about the package and printed them as statements.** Found while
+  packaging two real apps to test 0.27.0. Without `-Metadata`, the report claimed `_Beschreibung folgt._`
+  as the Company-Portal text — which is copied into Intune verbatim and reads like a finished field —
+  plus `Start-ADTMsiProcess` and "Nutzerdaten bleiben erhalten" as the hook contents, for whatever package
+  happened to be reported on. A WinMerge package that only ever calls `Start-ADTProcess` with Inno Setup
+  switches was described four times as using a cmdlet it never touches. Nothing marked any of it as a guess.
+- **Hooks and the cmdlet list are now read out of the real launcher by AST**, per `*-ADTDeployment`
+  function. No launcher to read means `nicht ermittelbar / not derivable` instead of a plausible list. An
+  explicit `-Metadata` value still wins.
+- **A missing description warns and is marked visibly — and is refused outright when
+  `decisions.upload = true`**, in the same shape as the existing SYSTEM-test gate.
+  `-AllowMissingDescription` is the deliberate, visible opt-out.
+- **The header status is derived from the evidence** instead of defaulting to `Upload-bereit - getestet`.
+- **SKILL.md Phase 8** now says the description is mandatory; before, it only said how to format it.
+  Suite 474 → 484.

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,11 +50,16 @@ researched defaults; recommended option first.
    > you do, because `Add-AppxPackage` under SYSTEM reports success while registering the app for
    > nobody.
 
+   Plus any **external runtime prerequisite** Phase 2 found: separate package + Intune dependency
+   (recommended) / bundle it / document as manual / skip. Options + why: phase 1.4.
+
 <!-- rule:gate-deployment-semantics -->
 2. **Deployment semantics** - target audience (Required / Available / both, + AAD groups), uninstall "what
    goes vs. what stays", repair strategy, reboot behaviour (never / 3010 / 1641). Pre-select defaults from
    the installer type. Group assignment is **opt-in**: only when the user wants it here do you create/assign
    Entra groups (Phase 10, config `intune.groups`, guide Appendix M); the default is upload-without-assignment.
+   An **NSIS MultiUser** installer also needs its scope chosen here - all-users (recommended, matches a
+   System-context install) or current-user, which moves the detection rule into the profile. App. L.7.
 <!-- rule:gate-system-test-consent -->
 3. **SYSTEM-test consent** - it installs the real software as SYSTEM. Offer the Windows Sandbox route
    FIRST (`Invoke-PsadtSandboxTest.ps1`: whole loop, ~6 min, host untouched, no elevation), the DEV-VM
@@ -165,7 +170,9 @@ at the end. Resolve scope via gates 1 + 2 only, every option pre-filled from res
 
 **Phase 2 - Research fan-out (parallel sub-agents, no asking back).** Dispatch the three Researcher
 roles concurrently and show the findings table before scaffold. Record per deployment type: switch,
-expected exit codes, log path, known leftovers.
+expected exit codes, log path, known leftovers. **Also whether the app needs a runtime it does not
+bundle** - a GREEN Phase 6 proves the PACKAGE works, never that the app does; surface it at Gate 1
+(phase 1.4).
 **For an MSI the probe IS the research: `pwsh scripts/Get-PsadtMsiFacts.ps1 -Path <msi> -AsText`** -
 identity, signature, SHA256, features, decoded upgrade flags, shortcuts, file versions, registry rows and
 the Icon table in one call. Read it BEFORE web-searching anything; never hand-roll it (App. G).
@@ -190,12 +197,10 @@ user data) and async-retry loops for services: phase 4. WinGet hooks: App. I.3. 
 rule (a GUID passed to `-FilePath` throws `InvalidFilePathParameterValue` -> 60001) applies to Uninstall
 AND Repair - Repair is the usual miss. Custom helpers always go in
 `PSAppDeployToolkit.Extensions.psm1`, never the launcher.
-**If the installer stages a 3rd-party driver** (the Windows device-software prompt blocks a SYSTEM-silent
-install), classify it first: `pwsh scripts/Get-DriverSignatureInfo.ps1 -Path <extracted content>`.
-MicrosoftSigned -> pre-stage with pnputil in Pre-Install. VendorSigned -> certificate deliverable now
-(prefer the Intune policy), then pre-stage. Unsigned -> STOP, there is no packaging trick. Kernel-mode +
-vendor signature is RED, not a warning: TrustedPublisher silences the prompt but never satisfies Code
-Integrity. Tree: App. Q.
+**If the installer stages a 3rd-party driver** (the device-software prompt blocks a SYSTEM-silent
+install), classify it FIRST: `pwsh scripts/Get-DriverSignatureInfo.ps1 -Path <extracted content>`.
+**Unsigned is a hard stop, and kernel-mode with a vendor signature is RED, not a warning.** Verdict
+table, the pnputil staging route and the certificate options: App. Q.1.
 
 <!-- rule:preflight-green-gate -->
 **Phase 5 - Pre-flight (Reviewer gate).** `scripts/Invoke-PsadtPreflight.ps1 -PackagePath <pkg>` returns
@@ -210,24 +215,22 @@ Company-Portal uninstall returns 0x80070001). Per-check explanations and the enc
 - and that decision is recorded as `decisions.upload` in the manifest, which is what the dossier enforces.
 Each run appends to `results.systemTest[]` + `artifacts.logs[]`.
 
-**Default route: `pwsh scripts/Invoke-PsadtSandboxTest.ps1 -PackagePath <pkg>`.** It runs the WHOLE loop -
-Install, detection, Uninstall, detection, Reinstall, Repair, final Uninstall - inside one throwaway
-Windows Sandbox, every action as SYSTEM, and returns `{ Verdict, Steps, FailedAssertions, Assertions,
-ResultPath, LogFolder }`. No elevation on the host, host untouched, ~6 minutes. The verdict is keyed on
-the DETECTION SCRIPT (what Intune evaluates); package facts go in as `-PathsPresentAfterInstall` /
-`-PathsAbsentAfterInstall` / `-PathsAbsentAfterUninstall`. Needs the optional feature
-`Containers-DisposableClientVM` (the script prints the one-time enable command). Not usable when the app
-needs domain join, a real TPM or GPU - fall back to the per-action route.
+**Default route: `pwsh scripts/Invoke-PsadtSandboxTest.ps1 -PackagePath <pkg>`.** The WHOLE loop inside
+one throwaway Windows Sandbox, every action as SYSTEM. No elevation on the host, host untouched,
+~6 minutes. The verdict is keyed on the DETECTION SCRIPT - what Intune evaluates. Prerequisite, the
+`-Paths*` package assertions and when the sandbox is the wrong host: phase 6.1.
 
 **Never hand-roll this harness.** Running actions as SYSTEM and reading their exit codes back looks like
 ten lines of `schtasks` and is not: App. G has three bugs that each silently burned a full VM run.
 
+**After GREEN, offer a manual interactive test** for an unfamiliar app/vendor or a suspected runtime
+prerequisite - situational, not a gate. A missing runtime, a first-run wizard or an absent licence all
+leave the loop GREEN, because nothing in it ever launches the app. How: phase 6.4.
+
 **Per-action route (DEV VM, or when the sandbox cannot host the app).** `Invoke-PsadtSystemTest.ps1` runs
-ONE action as SYSTEM and returns `{ DeploymentType, ExitCode, Success, DetectionState, LogPath, LogTail,
-ErrorLines, Elevated }`; it fixes nothing - YOU drive the loop, hard cap 5 iterations. Needs an ELEVATED
-session + WinPS 5.1 on a DEV VM (Gate 3 consent + snapshot first). Loop: Install -> verify detection ->
-Uninstall -> verify clean -> Reinstall. Converged -> leave the machine uninstalled. Cap reached or no
-elevation -> blockade protocol, STOP before any upload. Prerequisites + diagnosis: phase 6, App. A, App. G.
+ONE action as SYSTEM and fixes nothing - **YOU drive the loop, hard cap 5 iterations**, on an ELEVATED
+WinPS 5.1 session (Gate 3 consent + snapshot first). The loop, the convergence rule and the blockade
+exit: phase 6.2. Diagnosis: App. A, App. G.
 
 **Phase 7 - Package.** `pwsh scripts/Invoke-PsadtPackage.ps1 -PackagePath <pkg>` - one command, never a
 hand-typed `IntuneWinAppUtil` line. It derives the name from the manifest, packs via a private temp `-o`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psadt-deploy-skill",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "Installer for the psadt-deploy Claude Code skill: build, test and deploy PSADT v4.x Intune Win32 packages.",
   "keywords": [
     "psadt",

--- a/references/appendix-l-installers.md
+++ b/references/appendix-l-installers.md
@@ -25,6 +25,9 @@ the natural detection rule.
 - File metadata/strings: `(Get-Item setup.exe).VersionInfo`; a `strings`-style scan for marker text.
 - **Inno Setup:** EXE contains `Inno Setup` / `JR.Inno.Setup`; uninstaller `unins000.exe`.
 - **NSIS:** EXE contains `Nullsoft.NSIS` / `NullsoftInst`; uninstaller `Uninstall.exe` / `uninst.exe`.
+  A PE-metadata scan (`file`, or any equivalent) reports it directly as `Nullsoft Installer self-extracting
+  archive`, which is cheaper and less ambiguous than a strings grep. Then check whether it is a
+  **MultiUser** build (L.7) BEFORE trusting a bare `/S`.
 - **InstallShield:** `setup.exe` + `*.cab` / `data1.hdr` / `0x0409.ini`; strings `InstallShield` / `ISSetupStream`;
   `ISInternalDescription "Setup Launcher"`. Basic-MSI vs InstallScript: extract (7-Zip) - an embedded `.msi`
   + `Windows Installer` strings => Basic MSI; `data1.cab`/`setup.inx`/`_isres*` => InstallScript.
@@ -62,7 +65,7 @@ the natural detection rule.
 | **InstallShield (Basic MSI)** | `setup.exe /s /v"/qn"` | ProductCode | `/v"/norestart"` | `/v"/l*v log"` | ProductCode | |
 | **InstallShield (InstallScript)** | `setup.exe /s /f1"setup.iss"` | `setup.exe /s /x /f1"uninstall.iss"` | (ISS-driven) | `/f2"log"` | registry / file | record the `.iss` with `setup.exe /r /f1"setup.iss"` |
 | **Inno Setup** | `setup.exe /VERYSILENT /SUPPRESSMSGBOXES /SP- /NORESTART` | `unins000.exe /VERYSILENT /NORESTART` | `/NORESTART` (**mandatory**, see L.7) | `/LOG="log"` | QuietUninstallString / registry | `/SILENT` shows a progress bar, `/VERYSILENT` none; `/SUPPRESSMSGBOXES` only works WITH one of them |
-| **NSIS** | `setup.exe /S` | `Uninstall.exe /S _?=<installdir>` (see L.7) | (installer-specific) | `/D=path` (last arg, unquoted) | registry / file | `/S` is case-SENSITIVE; a bare `Uninstall.exe /S` returns BEFORE it is done |
+| **NSIS** | `setup.exe /S` (add `/allusers` or `/currentuser` if MultiUser - see L.7) | `Uninstall.exe /S _?=<installdir>` (see L.7) | (installer-specific) | `/D=path` (last arg, unquoted) | registry / file | `/S` is case-SENSITIVE; a bare `Uninstall.exe /S` returns BEFORE it is done |
 | **Advanced Installer** | `msiexec /i pkg.msi /qn` | `msiexec /x {ProductCode} /qn` | `/norestart` | `/l*v "log"` | MSI ProductCode | plain MSI underneath; a fresh ProductCode per build is typical - re-probe every time (**L.6**) |
 | **WiX Burn bundle** | `bundle.exe /quiet /norestart` | `bundle.exe /uninstall /quiet` | `/norestart` | `/log "log"` | registry (BundleProviderKey) / file version | wraps MSIs; a single ProductCode is unreliable |
 | **Squirrel (Electron)** | `Setup.exe --silent` | `%LocalAppData%\<App>\Update.exe --uninstall -s` | n/a | n/a | file version under `%LocalAppData%` | usually PER-USER; a System/Win32 install needs care |
@@ -193,6 +196,31 @@ must be removed by the package afterwards.
   NSIS install lands in the default directory anyway.
 - **`/NCRC`** skips the CRC check, unless the script used `CRCCheck force` - in which case the flag is
   ignored rather than honoured.
+
+**NSIS MultiUser (`MultiUser.nsh`): a bare `/S` aborts instantly and installs nothing.** A large and
+growing share of NSIS installers are built with the MultiUser plugin so one installer can target either
+scope. When the script defines `MULTIUSER_INSTALLMODE_COMMANDLINE`, running it silently WITHOUT an
+explicit scope switch fails the command-line validation in `.onInit` and the process exits immediately -
+typically well under a second, before a single file is written, with **no stdout and no stderr at all**
+regardless of window mode.
+
+- **Fix:** pass `/allusers` (machine-wide) or `/currentuser` (per-user) alongside `/S`. Default to
+  **`/allusers`** for an Intune System-context deployment; use `/currentuser` only when the app is
+  deliberately per-user. Case matters for the bare `/S` only (L.2), not for the mode switch.
+- **This is the tell:** an installer confirmed as genuine NSIS (L.1) that nevertheless fails
+  near-instantly under `/S` alone, with no captured output and no partial install artefacts, is very
+  likely MultiUser-gated. Confirm behaviourally with `/S /allusers` before concluding the switch table's
+  plain `/S` is wrong for that build.
+- **`/currentuser` installs are invisible to a `C:\Program Files\...` detection rule by design** - they
+  land under the user's own profile. If `/currentuser` is chosen, the detection rule has to look there.
+  Do not read "nothing under Program Files" as a failed install without checking for exit code 0 first.
+
+> Measured 2026-09-11 on one vendor's installer: an instant, output-free failure reproduced identically
+> under SYSTEM, under a fully interactive admin session, and via a raw scheduled task that bypassed
+> PSADT entirely - which rules out account, session and window creation and leaves the missing switch.
+> The observed exit code was `666660`. Treat the exact number as one data point, not as a signature:
+> MultiUser scripts are free to choose their own abort code. The reliable signature is the SHAPE -
+> genuine NSIS, sub-second exit, no output, nothing written.
 
 ### L.8 MSIX / AppX - staging vs registration, and why SYSTEM breaks the obvious call
 

--- a/references/phases-0-6.md
+++ b/references/phases-0-6.md
@@ -12,6 +12,7 @@
 - [1.1 Check the current PSADT version](#11-check-the-current-psadt-version)
 - [1.2 Intake questions about the app (before a single line of code exists)](#12-intake-questions-about-the-app-before-a-single-line-of-code-exists)
 - [1.3 Web research on the specific installer](#13-web-research-on-the-specific-installer)
+- [1.4 External runtime prerequisites the installer does not bundle](#14-external-runtime-prerequisites-the-installer-does-not-bundle)
 - [3.1 Load the module, generate the scaffold](#31-load-the-module-generate-the-scaffold)
 - [3.2 What the scaffold produces](#32-what-the-scaffold-produces)
 - [3.3 First verification of the scaffold](#33-first-verification-of-the-scaffold)
@@ -28,6 +29,7 @@
 - [6.1 Default route: the whole loop in a Windows Sandbox](#61-default-route-the-whole-loop-in-a-windows-sandbox)
 - [6.2 Per-action route (DEV VM, or an app the sandbox cannot host)](#62-per-action-route-dev-vm-or-an-app-the-sandbox-cannot-host)
 - [6.3 Run it in parallel with Phases 7 and 8](#63-run-it-in-parallel-with-phases-7-and-8)
+- [6.4 The manual interactive test a GREEN verdict cannot replace](#64-the-manual-interactive-test-a-green-verdict-cannot-replace)
 
 ## Phase 0: Setup (Doctor)
 
@@ -254,6 +256,7 @@ Research per app - without these answers there is no successful silent install:
 | Known exit codes (success, reboot, error) | `0, 3010, ...` | |
 | Installer log file path | `<...>` | |
 | Dependency installer (if separate) | `<...>` | |
+| External runtime prerequisite (1.4) | `<...>` | |
 | Known Intune pitfalls | `<...>` | |
 | Known post-install config (registry / XML) | `<...>` | |
 
@@ -268,6 +271,34 @@ Without this table filled in: **do not package**.
 - Docs: https://docs.oracle.com/en/database/oracle/oracle-database/21/xeinw/
 - Silent install: `setup.exe /s /f1"XEInstall.rsp"` + response file
 - Known pitfall: `svc_oracle` must exist BEFORE install (which is why the script creates the service account)
+
+### 1.4 External runtime prerequisites the installer does not bundle
+
+<!-- rule:runtime-prerequisite -->
+**Research whether the app needs a separate runtime it does not carry, and surface the answer at
+Gate 1.** This is its own question because no later phase can ask it. Phase 5 parses the package,
+Phase 6 drives Install/Detect/Uninstall/Repair against the detection script, and Phase 11 watches the
+delivery - none of them ever launches the application. A package can therefore pass every gate GREEN
+while the installed app is inert, and the first person to find out is the user it was assigned to.
+
+The shape to look for: an app whose vendor ships the runtime as a *separate* download and expects it
+to be present - R for RStudio, a JRE for several Java IDEs, a specific .NET Desktop Runtime version an
+installer references but does not include. A bundled or chained runtime is not this case; the test is
+whether a clean machine that ran only this installer can actually start the app.
+
+Answer it from the vendor's system-requirements or enterprise-deployment page, not from a forum post -
+and treat the answer as a claim until something confirms it (`research-is-data`, `references/research-trust.md`).
+
+When one is found, it is a **Gate 1 option set**, never a silent decision:
+
+| Option | When |
+|---|---|
+| Separate package + Intune app dependency | **Recommended.** The runtime is versioned, reusable across apps and visible in Intune. |
+| Bundle the runtime installer into this package | One consumer, or the vendor pins an exact runtime build. |
+| Document as a manual prerequisite | The runtime is already managed elsewhere and only needs recording. |
+| Skip for now | A deliberate, recorded decision - it lands in the manifest and in the dossier. |
+
+Record the choice in the manifest with the rest of the Gate 1 answers, so the dossier reports it.
 
 ---
 
@@ -595,10 +626,49 @@ Requires an elevated session (a SYSTEM scheduled task) and Windows PowerShell 5.
 script re-execs itself into 5.1 when started from pwsh. Cannot run either route? STOP before `-Execute` and
 hand the exact command back - never upload untested.
 
+The script returns `{ DeploymentType, ExitCode, Success, DetectionState, LogPath, LogTail, ErrorLines,
+Elevated }` and **fixes nothing**. You drive the loop, and the loop is bounded:
+
+```
+Install -> verify detection -> Uninstall -> verify clean -> Reinstall
+```
+
+- **Hard cap: 5 iterations.** Not a suggestion - it is what keeps a failing package from turning into
+  an unbounded edit-and-retry session against a VM.
+- **Converged** -> run Uninstall once more and leave the machine uninstalled. A DEV VM left in the
+  installed state makes the next package's "absent" baseline a lie.
+- **Cap reached, or no elevation available** -> blockade protocol (PROBLEM / TRIED / OPTIONS), and STOP
+  before any upload. A package whose Uninstall never ran is not a finished package.
+
+Prerequisites and the diagnosis path for a failing action: Appendix A (error catalogue) and
+Appendix G (the harness bugs, and why this is not ten lines of `schtasks`).
+
 ### 6.3 Run it in parallel with Phases 7 and 8
 
 Packaging and the dossier do not depend on the test result; only the verdict *recorded in* the dossier
 does. Start the sandbox test, build the `.intunewin` and the report while it runs, then fold the result in
 and regenerate the dossier. Serialising them adds the whole test duration to the wall clock for nothing.
+
+### 6.4 The manual interactive test a GREEN verdict cannot replace
+
+**After a GREEN verdict, offer a manual interactive test.** Situational, not a fifth gate: skip it
+silently for a vendor or app family already packaged and understood. Offer it for an unfamiliar
+app or vendor, for anything flagged in 1.4, and for the first package of a new app family.
+
+What GREEN actually means is *the package installs, detects, uninstalls, reinstalls and repairs against
+the detection script*. It does not mean the application works. Invisible to the loop by construction:
+a missing external runtime (1.4), a first-run wizard that blocks on a click, an absent licence, a
+default configuration that is broken in this environment. Every one of those leaves the package GREEN.
+
+The cheap version: generate the artefacts without booting the automated loop, then hand the user a
+sandbox with nothing in it but the installer.
+
+```powershell
+# Generate only - no run, no Startup trigger, no automated loop.
+pwsh scripts/Invoke-PsadtSandboxTest.ps1 -PackagePath <pkg> -GenerateOnly
+```
+
+Take the `.wsb` it writes, keep the package mapping, drop the work-folder mapping, and open it. The
+user installs and clicks around by hand. That is the check no assertion in this skill can make for them.
 
 ---

--- a/scripts/Invoke-PsadtSandboxTest.ps1
+++ b/scripts/Invoke-PsadtSandboxTest.ps1
@@ -63,6 +63,12 @@ param(
 
     [ValidateRange(2048, 32768)][int]$MemoryInMB = 6144,
 
+    # Guest-side wait, inside the Startup trigger, before the runner starts reading the mapped folder.
+    # Some hosts see the mapped-folder mount land empty when the guest uses it too soon after logon; this
+    # pause happens after the guest has logged on, giving the mount extra time to settle. 0 disables it.
+    # Host-specific rather than a fixed cost - tune it down once a working value is known.
+    [ValidateRange(0, 900)][int]$GuestSettleDelaySeconds = 0,
+
     # Leave the VM running at the end instead of shutting it down. For looking at a failure by hand.
     [switch]$KeepSandboxOpen,
 
@@ -176,7 +182,7 @@ $runnerTemplate = @'
 # Drives the full Phase 6 loop with every deployment action executed as NT AUTHORITY\SYSTEM.
 $ErrorActionPreference = 'Stop'
 
-$mapped   = 'C:\Users\WDAGUtilityAccount\Desktop\__WORKLEAF__'
+$mapped   = '__MAPPEDROOT__'
 $pkgSrc   = 'C:\Users\WDAGUtilityAccount\Desktop\__PACKAGELEAF__'
 $results  = Join-Path $mapped 'results'
 $work     = 'C:\PsadtSandboxWork'
@@ -206,6 +212,23 @@ function Add-Assertion {
     if (-not $Ok) { $script:report.failedAssertions += $Name }
 }
 
+function Get-SchtasksFailure {
+    <#
+      Both schtasks calls used to be piped to Out-Null with no exit-code check, so ANY failure to
+      create or start the task presented as the action timing out $actionTimeout seconds later - the
+      one symptom that says nothing about the cause. The likeliest real cause is a token problem:
+      /RU SYSTEM /RL HIGHEST needs the full administrator token, and a Startup-folder item does not
+      always carry one.
+    #>
+    param([string]$Operation, [string]$TaskName, [int]$Code, [string]$ErrFile)
+
+    $detail = ''
+    if (Test-Path -LiteralPath $ErrFile) {
+        $detail = (('' + (Get-Content -LiteralPath $ErrFile -Raw -ErrorAction SilentlyContinue)) -replace '\s+', ' ').Trim()
+    }
+    "schtasks /$Operation failed for '$TaskName' (exit $Code). $detail"
+}
+
 function Invoke-AsSystem {
     <#
       Runs one command line as SYSTEM through a scheduled task and returns { ExitCode, Output, TimedOut }.
@@ -233,8 +256,20 @@ function Invoke-AsSystem {
         "echo %ERRORLEVEL% > `"$codeFile`""
     ) | Set-Content -LiteralPath $cmdFile -Encoding ASCII
 
-    & schtasks.exe /Create /TN $taskName /TR "`"$cmdFile`"" /SC ONCE /ST 00:00 /RU 'SYSTEM' /RL HIGHEST /F | Out-Null
-    & schtasks.exe /Run /TN $taskName | Out-Null
+    # /Run starts the task immediately, so the ONCE trigger exists only because /Create demands one.
+    # 00:00 is in the past ON PURPOSE: a trigger that can never fire by itself cannot re-launch this
+    # deployment .cmd as SYSTEM behind the loop's back while the action is still running. schtasks says
+    # so on STDERR ("Task may not run because /ST is earlier than current time") on every single step -
+    # that notice is the design working, so it is suppressed rather than designed away with a
+    # near-future /ST. A formatted time would be culture-dependent on top: 'HH:mm' renders as 15.02
+    # under fi-FI, which schtasks rejects with "Invalid start time value", creating no task at all.
+    # $ErrorActionPreference is 'Stop' here and WinPS 5.1 turns a native command's stderr merged via
+    # 2>&1 into terminating ErrorRecords, so stderr goes to a file instead of through the pipeline.
+    $schtasksErr = Join-Path $work "$Label.schtasks.err"
+    & schtasks.exe /Create /TN $taskName /TR "`"$cmdFile`"" /SC ONCE /ST 00:00 /RU 'SYSTEM' /RL HIGHEST /F 2>$schtasksErr | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw (Get-SchtasksFailure -Operation 'Create' -TaskName $taskName -Code $LASTEXITCODE -ErrFile $schtasksErr) }
+    & schtasks.exe /Run /TN $taskName 2>$schtasksErr | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw (Get-SchtasksFailure -Operation 'Run' -TaskName $taskName -Code $LASTEXITCODE -ErrFile $schtasksErr) }
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     $raw = $null
@@ -250,8 +285,22 @@ function Invoke-AsSystem {
 
     if (-not $raw) { return [pscustomobject]@{ ExitCode = $null; Output = ''; TimedOut = $true } }
 
+    # The .cmd writes the output file and the exit-code file on two consecutive lines, but that does not
+    # guarantee the output file's bytes are visible to THIS process the moment the exit-code file is:
+    # Defender briefly locking a freshly-written file for a scan is enough to turn the -ErrorAction
+    # SilentlyContinue read into a silently EMPTY result, which a detection step then reads as "not
+    # detected". Observed exactly that - a step captured stdout as '' while the same file, re-read when
+    # the evidence was copied out at the end of the run, held the real result all along. The retry
+    # separates a genuinely empty result (stays empty across every attempt - the normal case for an
+    # absent app) from a transiently unreadable one (fills in within an attempt or two).
     [string]$out = ''
-    if (Test-Path -LiteralPath $outFile) { $out = '' + (Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue) }
+    if (Test-Path -LiteralPath $outFile) {
+        for ($i = 0; $i -lt 3; $i++) {
+            $out = '' + (Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue)
+            if ($out) { break }
+            Start-Sleep -Milliseconds 300
+        }
+    }
     return [pscustomobject]@{ ExitCode = [int]$raw.Trim(); Output = $out; TimedOut = $false }
 }
 
@@ -292,6 +341,18 @@ function Test-Paths {
 try {
     New-Item -ItemType Directory -Path $results, $work -Force | Out-Null
     Start-Transcript -LiteralPath (Join-Path $results 'sandbox-transcript.txt') -Force | Out-Null
+
+    # Every deployment action below goes through schtasks /RU SYSTEM /RL HIGHEST, which needs the full
+    # administrator token. <LogonCommand> supplied one implicitly; a Startup-folder item is launched by
+    # Explorer and inherits the token Explorer holds, so this stopped being true by construction when
+    # the trigger moved. Fail here in one second rather than let all seven actions fail identically
+    # further down, where the evidence points at the package instead.
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $isElevated = ([Security.Principal.WindowsPrincipal]$identity).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    Add-Step 'Elevation' @{ elevated = $isElevated; identity = $identity.Name }
+    if (-not $isElevated) {
+        throw "The sandbox runner is not elevated, so schtasks /RU SYSTEM /RL HIGHEST cannot work. The Startup-folder trigger handed it a filtered token."
+    }
 
     # The mapped package folder is read-only and PSADT unblocks files under its own root, so work on a copy.
     Copy-Item -LiteralPath $pkgSrc -Destination $pkg -Recurse -Force
@@ -353,8 +414,15 @@ finally {
 }
 '@
 
+# Windows auto-executes only recognised extensions (.exe/.bat/.cmd/.lnk/.vbs) placed DIRECTLY in the
+# Startup folder, and a bare .ps1 loose in there additionally makes Explorer raise its own "how do you
+# want to open this file" prompt. So the runner lives in a 'runner' subfolder and only the one-line
+# trigger .cmd stays loose in Startup.
+$guestStartup = 'C:\Users\WDAGUtilityAccount\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup'
+$guestRunner  = Join-Path $guestStartup 'runner\Run-PsadtSandboxTest.ps1'
+
 $runner = $runnerTemplate.
-    Replace('__WORKLEAF__', $workLeaf).
+    Replace('__MAPPEDROOT__', $guestStartup).
     Replace('__PACKAGELEAF__', $packageLeaf).
     Replace('__DETECTIONSCRIPT__', ($DetectionScript -replace "'", "''")).
     Replace('__SUCCESSCODES__', ('@(' + ($SuccessExitCodes -join ', ') + ')')).
@@ -363,8 +431,24 @@ $runner = $runnerTemplate.
     Replace('__PATHSABSENTINSTALL__', (ConvertTo-PsArrayLiteral $PathsAbsentAfterInstall)).
     Replace('__PATHSABSENTUNINSTALL__', (ConvertTo-PsArrayLiteral $PathsAbsentAfterUninstall))
 
-$runnerPath = Join-Path $workFolder 'Run-PsadtSandboxTest.ps1'
+$runnerPath = Join-Path $workFolder 'runner\Run-PsadtSandboxTest.ps1'
+New-Item -ItemType Directory -Path (Split-Path $runnerPath -Parent) -Force | Out-Null
 [System.IO.File]::WriteAllText($runnerPath, $runner, [System.Text.UTF8Encoding]::new($true))
+
+# --- 4b. Startup-folder trigger (works around microsoft/Windows-Sandbox#125) ------------------------
+# On the affected Windows Sandbox app version, <LogonCommand> silently never executes at all - not
+# hidden, not delayed, the process is never spawned - while MappedFolders keeps working normally. The
+# documented workaround is to map a host folder straight onto the guest's Startup folder: that path is
+# driven by Windows' own logon mechanism rather than by the Sandbox app's LogonCommand code path, so
+# the bug does not reach it. The work folder itself is mapped there instead of adding a third mapping.
+$triggerLine = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$guestRunner`""
+if ($GuestSettleDelaySeconds -gt 0) {
+    # ping, not timeout: timeout needs a console it owns and aborts with "input redirection is not
+    # supported" when it does not have one.
+    $triggerLine = "ping.exe -n $($GuestSettleDelaySeconds + 1) 127.0.0.1 > nul & " + $triggerLine
+}
+$triggerScript = "@echo off`r`n$triggerLine`r`n"
+[System.IO.File]::WriteAllText((Join-Path $workFolder 'StartupTrigger.cmd'), $triggerScript, [System.Text.ASCIIEncoding]::new())
 
 # --- 5. Generate the .wsb configuration -------------------------------------------------------------
 $wsbPath = Join-Path $workRoot "$stem.wsb"
@@ -380,12 +464,10 @@ $wsb = @"
     </MappedFolder>
     <MappedFolder>
       <HostFolder>$workFolder</HostFolder>
+      <SandboxFolder>$guestStartup</SandboxFolder>
       <ReadOnly>false</ReadOnly>
     </MappedFolder>
   </MappedFolders>
-  <LogonCommand>
-    <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\Users\WDAGUtilityAccount\Desktop\$workLeaf\Run-PsadtSandboxTest.ps1</Command>
-  </LogonCommand>
 </Configuration>
 "@
 [System.IO.File]::WriteAllText($wsbPath, $wsb, [System.Text.UTF8Encoding]::new($false))
@@ -405,7 +487,11 @@ $sandboxExe = Join-Path $env:WINDIR 'System32\WindowsSandbox.exe'
 if (-not (Test-Path -LiteralPath $sandboxExe)) { throw "WindowsSandbox.exe not found at '$sandboxExe'." }
 
 Write-Verbose "Starting Windows Sandbox with $wsbPath"
-Start-Process -FilePath $sandboxExe -ArgumentList $wsbPath | Out-Null
+# Start-Process does not quote -ArgumentList elements itself. A path containing a space - routine as
+# soon as the Windows username has one, which also puts one in %LOCALAPPDATA% - is split into several
+# argv entries, so WindowsSandbox.exe receives a garbled config path and boots with NO custom
+# MappedFolders at all. It reports no error while doing it, which reads exactly like an upstream bug.
+Start-Process -FilePath $sandboxExe -ArgumentList "`"$wsbPath`"" | Out-Null
 
 $hostDeadline = (Get-Date).AddMinutes($TotalTimeoutMinutes)
 $sawSandbox = $false

--- a/tests/Invoke-PsadtSandboxTest.Tests.ps1
+++ b/tests/Invoke-PsadtSandboxTest.Tests.ps1
@@ -249,6 +249,43 @@ Describe 'Invoke-PsadtSandboxTest' {
         }
     }
 
+    Context 'runner: running an action as SYSTEM' {
+        BeforeEach { $script:sysRunner = Get-Content -LiteralPath (& $script:script -PackagePath $script:pkg -GenerateOnly).RunnerPath -Raw }
+
+        It 'keeps the ONCE trigger in the past so it can never fire on its own' {
+            # /Run starts the task; the trigger only exists because /Create demands one. A near-future
+            # /ST silences the stderr notice by ARMING a real trigger, which can re-launch the same
+            # deployment .cmd as SYSTEM while the action is still running.
+            $script:sysRunner | Should -Match '/SC ONCE /ST 00:00'
+        }
+
+        It 'never formats the start time through the current culture' {
+            # 'HH:mm' takes ':' as the culture's TimeSeparator: under fi-FI it renders 15.02, and
+            # schtasks rejects that with "Invalid start time value" and creates no task at all.
+            $script:sysRunner | Should -Not -Match "ToString\('HH:mm'\)"
+        }
+
+        It 'checks the exit code of both schtasks calls' {
+            # Unchecked, any failure to create or start the task presents as the action timing out
+            # $actionTimeout seconds later - the one symptom that says nothing about the cause.
+            $script:sysRunner | Should -Match "Get-SchtasksFailure -Operation 'Create'"
+            $script:sysRunner | Should -Match "Get-SchtasksFailure -Operation 'Run'"
+        }
+
+        It 'fails fast when the Startup trigger handed it a filtered token' {
+            # schtasks /RU SYSTEM /RL HIGHEST needs the full administrator token. LogonCommand supplied
+            # one implicitly; an Explorer-launched Startup item does not guarantee it.
+            $script:sysRunner | Should -Match 'WindowsBuiltInRole\]::Administrator'
+            $script:sysRunner | Should -Match 'not elevated'
+        }
+
+        It 'retries a captured output that reads back empty' {
+            # A transiently unreadable .out file (Defender scanning it) is otherwise indistinguishable
+            # from a detection script reporting "absent".
+            $script:sysRunner | Should -Match 'for \(\$i = 0; \$i -lt 3; \$i\+\+\)'
+        }
+    }
+
     Context 'generated .wsb' {
         BeforeEach { $script:gen = & $script:script -PackagePath $script:pkg -GenerateOnly }
 
@@ -264,9 +301,43 @@ Describe 'Invoke-PsadtSandboxTest' {
             ($folders | Where-Object { $_.HostFolder -like '*_PsadtSandboxTest' }).ReadOnly | Should -Be 'false'
         }
 
-        It 'starts the runner from the mapped work folder' {
+        It 'carries no LogonCommand - it silently never executes on the affected Sandbox app version' {
+            # microsoft/Windows-Sandbox#125: the process is never spawned at all, while MappedFolders
+            # keeps working. A LogonCommand here would look correct and do nothing.
             $xml = [xml](Get-Content -LiteralPath $script:gen.WsbPath -Raw)
-            $xml.Configuration.LogonCommand.Command | Should -Match 'Run-PsadtSandboxTest\.ps1'
+            $xml.Configuration.LogonCommand | Should -BeNullOrEmpty
+        }
+
+        It 'maps the work folder onto the guest Startup folder rather than the Desktop' {
+            $xml = [xml](Get-Content -LiteralPath $script:gen.WsbPath -Raw)
+            $folders = @($xml.Configuration.MappedFolders.MappedFolder)
+            $work = $folders | Where-Object { $_.HostFolder -like '*_PsadtSandboxTest' }
+            $work.SandboxFolder | Should -Be 'C:\Users\WDAGUtilityAccount\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup'
+        }
+
+        It 'starts the runner from a trigger .cmd placed loose in the work folder' {
+            # Only .exe/.bat/.cmd/.lnk/.vbs are auto-executed from Startup, so the entry point has to
+            # be the .cmd; the .ps1 it launches lives one level down.
+            $triggerPath = Join-Path $script:gen.SandboxWorkFolder 'StartupTrigger.cmd'
+            $triggerPath | Should -Exist
+            (Get-Content -LiteralPath $triggerPath -Raw) | Should -Match 'Run-PsadtSandboxTest\.ps1'
+        }
+
+        It 'keeps the runner .ps1 out of the Startup root, where Explorer prompts for it' {
+            # A bare .ps1 sitting directly in Startup makes Explorer raise its own "how do you want to
+            # open this file" dialog, even though the .cmd already launches it correctly.
+            $script:gen.RunnerPath | Should -Match 'runner.Run-PsadtSandboxTest\.ps1$'
+            (Join-Path $script:gen.SandboxWorkFolder 'Run-PsadtSandboxTest.ps1') | Should -Not -Exist
+        }
+
+        It 'waits inside the trigger only when a settle delay was asked for' {
+            $plain = Get-Content -LiteralPath (Join-Path $script:gen.SandboxWorkFolder 'StartupTrigger.cmd') -Raw
+            $plain | Should -Not -Match 'ping\.exe'
+
+            $delayed = & $script:script -PackagePath $script:pkg -GenerateOnly -GuestSettleDelaySeconds 20
+            $text = Get-Content -LiteralPath (Join-Path $delayed.SandboxWorkFolder 'StartupTrigger.cmd') -Raw
+            # ping, not timeout: timeout aborts without a console it owns.
+            $text | Should -Match 'ping\.exe -n 21 127\.0\.0\.1'
         }
     }
 

--- a/tests/rule-inventory.txt
+++ b/tests/rule-inventory.txt
@@ -36,3 +36,4 @@ preflight-green-gate         Invoke-PsadtPreflight.ps1 returns GREEN or RED and 
 phase6-system-test           The SYSTEM test loop, sandbox route by default, and the harness is never hand-rolled
 upload-dry-run-first         Dry-run, show the summary, confirm, only then -Execute; never delete, CreateNewCoexist
 assignment-dry-run-first     Dry-run and confirm before assigning; idempotent, never deletes, ambiguous names skipped
+runtime-prerequisite        An unbundled runtime the app needs is researched in Phase 2 and decided at Gate 1; a GREEN loop proves the package, not the app


### PR DESCRIPTION
Ports **#17** by @CSN-TechX onto current `main` and releases it as 0.28.0. That branch predated the 0.27.0 reference split, so it conflicts: it edits `references/PSADTv4-Deployment-Guide.md`, which no longer exists. The NSIS documentation is re-targeted to `references/appendix-l-installers.md`.

### Taken as submitted

- **Quote the `.wsb` path.** `Start-Process -ArgumentList` does not quote its elements, so any space split the path across argv entries and Windows Sandbox booted with the built-in shares only — no error, no warning. A Windows username with a space is enough, and it puts one in `%LOCALAPPDATA%` too.
- **Replace `<LogonCommand>` with a Startup-folder trigger** (microsoft/Windows-Sandbox#125 — the process is never spawned, while `MappedFolders` keeps working). The runner `.ps1` moves into `runner\`: Startup auto-executes only `.exe/.bat/.cmd/.lnk/.vbs`, and a loose `.ps1` there makes Explorer prompt.
- **Retry a captured output that reads back empty**, so a transiently locked file stops being indistinguishable from "app not detected".
- **`-GuestSettleDelaySeconds`**, implemented with `ping -n` rather than `timeout`, which aborts without a console it owns.
- **NSIS MultiUser needs an explicit `/allusers` or `/currentuser`**, now in App. L.1 / L.2 / L.7 and a Gate 2 decision. The observed exit code is recorded as one data point rather than a signature — the reliable tell is the shape: genuine NSIS, sub-second exit, no output, nothing written.
- **Runtime-prerequisite research** (Phase 2 → Gate 1, phase 1.4) and the **manual interactive test after a GREEN Phase 6** (phase 6.4).

### Changed from the PR, each with a test

- **The `/ST` warning is suppressed, not designed away.** Moving the trigger to now+1min arms a real ONCE trigger that can re-launch the deployment `.cmd` as SYSTEM mid-action — `MultipleInstancesPolicy` defaults to `IgnoreNew`, which covers overlap only. And `(Get-Date).ToString('HH:mm')` is culture-dependent: under fi-FI it renders `15.02`, which `schtasks` rejects with "Invalid start time value", creating no task at all. `00:00` stays, in the past on purpose, and its stderr notice goes to a file.
- **Both `schtasks` exit codes are checked.** Unchecked, any failure to create or start the task presented as a 900-second timeout — the one symptom that says nothing about the cause.
- **The runner asserts it is elevated before the first action.** `schtasks /RU SYSTEM /RL HIGHEST` needs the full administrator token. `<LogonCommand>` supplied one implicitly; an Explorer-launched Startup item does not guarantee it. Without this, a filtered token would make all seven actions fail identically and point the evidence at the package.

### SKILL.md and the compaction budget

The four new control-plane decisions cost 646 bytes ahead of the Phase-7 cut, where there were 43 to spare. Paid for by **moving three blocks into the appendices that already own them** — the driver decision tree to App. Q.1, the sandbox route detail to phase 6.1, and the per-action loop to phase 6.2, which never carried it and now does. Nothing was shortened. Phase 6 ends at byte 17456 of 17500.

### Verification

Full suite: **493 passed, 0 failed** (484 before). Nine new cases cover the Startup relocation, the trigger, the settle delay, the in-the-past `/ST`, the culture-safe formatting, both exit-code checks, the elevation guard and the read retry.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
