### PR TITLE
0.29.0: the sandbox ran nothing as SYSTEM and blamed the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to this skill. Newest first. This project follows a loose [SemVer](https://semver.org/).
 
+## 0.29.0 - 2026-09-11 - The sandbox ran nothing as SYSTEM and blamed the package
+
+Found while packaging Google Chrome for Intune - the first sandbox run on this host after 0.28.0. Five
+faults were stacked on top of each other, and every one of them hid the next: the run died before its
+first action, then every action timed out with no cause, then every action exited 60008 with no log, then
+60008 again for a different reason. Each was measured inside the guest with a standalone probe before it
+was fixed; nothing here was taken from a comment, a thread or a plausible theory.
+
+### Fixed
+- **The Startup-folder trigger from 0.28.0 could not run a single task as SYSTEM.** Explorer launches a
+  Startup item, and the resulting runner passes `IsInRole(Administrator)` yet cannot drive the Task
+  Scheduler: `schtasks /Create` and `/Run` both return exit 0 while the task never executes, and
+  `Register-ScheduledTask` is refused outright ("Cannot connect to CIM server. Access denied"). Every
+  deployment action then hit its full timeout with no cause, and the evidence pointed at the package.
+  `<LogonCommand>` is back - the five GREEN runs on this host before 0.28.0 all used it. What
+  [microsoft/Windows-Sandbox#125](https://github.com/microsoft/Windows-Sandbox/issues/125) describes is
+  left to the host's `DONE.txt` timeout, which already says "the runner never started".
+- **`schtasks`' own stderr notice killed the run before the first action.** The ONCE trigger is
+  deliberately in the past, so `schtasks` writes "/ST is earlier than current time" on every step. In
+  Windows PowerShell 5.1 that raises a terminating `NativeCommandError` under
+  `$ErrorActionPreference = 'Stop'` - and a `2>file` redirect does NOT prevent it, it only chooses where
+  the ErrorRecord is written (measured; the 0.28.0 comment claimed otherwise). The preference is lowered
+  around the three `schtasks` calls and around the final `shutdown.exe`; the exit-code checks stay.
+- **The sandbox image lacked a localized resource PSADT needs just to load.** PSADT imports
+  `Microsoft.PowerShell.Archive` at import time; the guest had no `de-DE\ArchiveResources.psd1` while
+  the de-DE host has it, and WinPS 5.1 throws instead of falling back to another culture. Every launcher
+  exited 60008 before writing one log line - for any package, not just this one. The host's culture
+  folders for the modules PSADT imports are shipped in the work folder and laid down in the guest
+  wherever they are missing (`GuestPrepare`).
+- **WMI refused SYSTEM inside the guest.** `Initialize-ADTModule` queries `Win32_ComputerSystem` and got
+  `0x80070005`, so `Open-ADTSession` threw - 60008 again, even after the import had been fixed. The same
+  guest image had passed on 2026-09-08; the host's cumulative updates of 2026-09-11 are the only change
+  in between. `GuestPrepare` verifies WMI and salvages, then resets, the repository
+  (`winmgmt /resetrepository` is what worked). Both are safe in a VM that is discarded minutes later.
+
+### Added
+- **Three canaries run before the loop.** `SystemTaskCanary` runs `whoami` as SYSTEM;
+  `PsadtModuleCanary` imports the package's toolkit AND opens a Silent session as SYSTEM. Each fails in
+  seconds with the real error text and names a HARNESS/environment fault, so a broken guest can no
+  longer look like a broken package. Elevation alone was proven necessary but not sufficient.
+- **A 60008 action is re-run once through `powershell.exe -File`** and its stderr recorded on the step
+  (`diagnostic`). `Invoke-AppDeployToolkit.exe` discards the `.ps1`'s stderr, and 60008 means nothing
+  was deployed, so the re-run is side-effect-free. It took two probe VMs to read that one line by hand.
+- **A heartbeat in the guest console.** Every SYSTEM action draws nothing on the desktop; the runner now
+  prints progress every ten seconds and sets the window title, so a healthy two-minute install no
+  longer looks identical to a hang to anyone watching the VM.
+- Suite 493 -> 501.
+
+### Changed
+- The `-GuestSettleDelaySeconds` wait moved into the LogonCommand (`cmd /c ping ...`) and is XML-escaped
+  on the way into the `.wsb`: an unescaped `&` there makes the whole configuration unparseable, and the
+  sandbox then boots with no mapped folders at all. The suite caught it before it shipped.
+
 ## 0.28.0 - 2026-09-11 - The sandbox booted without its mapped folders and said nothing
 
 Ported from [#17](https://github.com/pt1987/claude-code-psadt-skill/pull/17) by @CSN-TechX, found while

--- a/README.md
+++ b/README.md
@@ -429,6 +429,19 @@ The two most recent releases are below. **[CHANGELOG.md](CHANGELOG.md)** carries
 every release since 0.1.0, and nothing is ever removed from it - this section is a window onto it, not a
 second copy to keep in sync.
 
+### 0.29.0 - 2026-09-11
+- **Fixed: the 0.28.0 Startup-folder trigger could not run a single task as SYSTEM.** The runner passed
+  the elevation check, yet `schtasks /Create` and `/Run` returned 0 while the task never executed - every
+  action timed out blaming the package. `<LogonCommand>` is back; #125 is left to the host's DONE.txt timeout.
+- **Fixed: `schtasks`' stderr notice ended the run before the first action** - in WinPS 5.1 a `2>file`
+  redirect does not stop the terminating `NativeCommandError`; the preference is lowered around the call.
+- **Fixed: the sandbox image lacked `de-DE\ArchiveResources.psd1`**, which PSADT needs just to import,
+  and **WMI refused SYSTEM** (`Win32_ComputerSystem` -> `0x80070005`), which `Open-ADTSession` needs.
+  Both surfaced as 60008 on every action with no log. `GuestPrepare` ships the host's module resources
+  into the guest and repairs the WMI repository.
+- **Added: three canaries before the loop** (SYSTEM task, toolkit import, toolkit session), **a 60008
+  action is re-run once via `powershell.exe -File` to capture the stderr the `.exe` discards**, and a
+  **heartbeat in the guest console** so a healthy install no longer looks like a hang. Suite 493 -> 501.
 ### 0.28.0 - 2026-09-11
 - **Fixed: a space in the `.wsb` path silently disabled every custom mapped folder.** `Start-Process
   -ArgumentList` does not quote its elements, so Windows Sandbox booted with the built-in shares only -
@@ -448,19 +461,3 @@ second copy to keep in sync.
 - **Added: an unbundled runtime prerequisite is researched in Phase 2 and decided at Gate 1**, and a
   manual interactive test is offered after a GREEN Phase 6 - the loop proves the package works, never
   that the app does. Suite 484 -> 493.
-### 0.27.1 - 2026-09-10
-- **Fixed: the dossier invented facts about the package and printed them as statements.** Found while
-  packaging two real apps to test 0.27.0. Without `-Metadata`, the report claimed `_Beschreibung folgt._`
-  as the Company-Portal text — which is copied into Intune verbatim and reads like a finished field —
-  plus `Start-ADTMsiProcess` and "Nutzerdaten bleiben erhalten" as the hook contents, for whatever package
-  happened to be reported on. A WinMerge package that only ever calls `Start-ADTProcess` with Inno Setup
-  switches was described four times as using a cmdlet it never touches. Nothing marked any of it as a guess.
-- **Hooks and the cmdlet list are now read out of the real launcher by AST**, per `*-ADTDeployment`
-  function. No launcher to read means `nicht ermittelbar / not derivable` instead of a plausible list. An
-  explicit `-Metadata` value still wins.
-- **A missing description warns and is marked visibly — and is refused outright when
-  `decisions.upload = true`**, in the same shape as the existing SYSTEM-test gate.
-  `-AllowMissingDescription` is the deliberate, visible opt-out.
-- **The header status is derived from the evidence** instead of defaulting to `Upload-bereit - getestet`.
-- **SKILL.md Phase 8** now says the description is mandatory; before, it only said how to format it.
-  Suite 474 → 484.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psadt-deploy-skill",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Installer for the psadt-deploy Claude Code skill: build, test and deploy PSADT v4.x Intune Win32 packages.",
   "keywords": [
     "psadt",

--- a/references/appendix-g-lessons.md
+++ b/references/appendix-g-lessons.md
@@ -223,3 +223,53 @@ service reads from or writes to, and do it in the SERVICE as well - a package-on
 entirely whenever the service creates the folder first.
 
 ---
+
+### 2026-09-11 - Google Chrome: the sandbox ran nothing as SYSTEM and blamed the package
+
+The first sandbox run on this host after 0.28.0. The package was fine from the start - it went GREEN on
+the first run whose harness actually worked (14 steps, 9.9 minutes, no failed assertion). Getting there
+took five stacked faults, each hiding the next, and about two hours. What made it expensive was not any
+one fault but reading each symptom as a package problem.
+
+**1. `elevated=True` is not evidence that anything can run as SYSTEM.** 0.28.0 had moved the runner from
+`<LogonCommand>` to a Startup-folder trigger and added an `IsInRole(Administrator)` assertion to guard
+the change. The assertion passed - and `schtasks /Create` + `/Run` returned exit 0 while the task never
+ran; `Register-ScheduledTask` said "Cannot connect to CIM server. Access denied". Explorer's token is not
+the token the Task Scheduler wants. **General lesson**: a precondition check must exercise the mechanism
+it guards, not a proxy for it. The harness now runs `whoami` as SYSTEM before anything else.
+
+**2. `2>file` does not suppress a native command's stderr under `$ErrorActionPreference='Stop'`.** The
+0.28.0 comment asserted it did; a ten-line probe under `powershell.exe` showed `THREW - NativeCommandError`.
+The redirect chooses where the ErrorRecord goes, not whether one is raised. **General lesson**: a comment
+that explains why code is safe is a claim. When the run dies exactly where the comment says it cannot,
+measure the claim before touching anything else.
+
+**3. A guest that looks like the host is not the host.** Two things the host had, the sandbox image did
+not: `Microsoft.PowerShell.Archive\de-DE\ArchiveResources.psd1` (PSADT imports that module at load, and
+WinPS 5.1 throws rather than falling back), and a WMI service that answers SYSTEM (`Win32_ComputerSystem`
+-> `0x80070005`, which `Initialize-ADTModule` needs). Both had worked on 2026-09-08; both broke with the
+host's cumulative updates of 2026-09-11, from which the sandbox image is built. Both surfaced as the same
+60008. **General lesson**: when every package fails identically, the environment is the suspect, not the
+package - and a guest image changes every Patch Tuesday even though nothing in the repository did.
+
+**4. `Invoke-AppDeployToolkit.exe` discards the `.ps1`'s stderr.** 60008 is "Initialization failed" and
+is raised before the first log line, so the `.exe` route leaves exactly one number and nothing else. It
+took two separate probe VMs to read the two lines that explained the two 60008s. The harness now re-runs
+a 60008 action once through `powershell.exe -File` with stderr captured, and its PSADT canary opens a
+real Silent session as SYSTEM so the next environment fault is named before the loop starts.
+
+**5. Never edit the package while the sandbox is running against it.** The package folder is mapped
+read-only into the VM and copied at the start of the run; a launcher edit mid-run produced a result that
+would have mixed old and new code. That run had to be thrown away. **General lesson**: finish every edit,
+re-run pre-flight, re-pack - then start the test, and touch nothing until the verdict.
+
+**6. A SYSTEM action draws nothing.** Twenty minutes of an idle-looking VM screen are indistinguishable
+from a hang, and "I see nothing happening" was correct - both when the tasks really did not run and later
+when the install was working. The runner now prints a heartbeat every ten seconds and sets the console
+title; the LogonCommand deliberately does not hide that window.
+
+**7. One probe VM beats an hour of reasoning.** Every fault above was settled by a three-minute sandbox
+that ran one command and wrote one text file back. The reasoning that preceded each probe was mostly
+wrong in detail and would have produced another blind full run.
+
+---

--- a/references/phases-0-6.md
+++ b/references/phases-0-6.md
@@ -664,7 +664,7 @@ The cheap version: generate the artefacts without booting the automated loop, th
 sandbox with nothing in it but the installer.
 
 ```powershell
-# Generate only - no run, no Startup trigger, no automated loop.
+# Generate only - no VM is started, nothing runs, no automated loop.
 pwsh scripts/Invoke-PsadtSandboxTest.ps1 -PackagePath <pkg> -GenerateOnly
 ```
 

--- a/scripts/Invoke-PsadtSandboxTest.ps1
+++ b/scripts/Invoke-PsadtSandboxTest.ps1
@@ -263,16 +263,36 @@ function Invoke-AsSystem {
     # that notice is the design working, so it is suppressed rather than designed away with a
     # near-future /ST. A formatted time would be culture-dependent on top: 'HH:mm' renders as 15.02
     # under fi-FI, which schtasks rejects with "Invalid start time value", creating no task at all.
-    # $ErrorActionPreference is 'Stop' here and WinPS 5.1 turns a native command's stderr merged via
-    # 2>&1 into terminating ErrorRecords, so stderr goes to a file instead of through the pipeline.
+    # $ErrorActionPreference is 'Stop' here, and in WinPS 5.1 a native command writing to stderr raises
+    # a terminating NativeCommandError REGARDLESS of a '2>file' redirect - the redirect chooses where the
+    # ErrorRecord is written, not whether one is raised. Suppressing the notice therefore needs the
+    # preference lowered around the call itself; with 2>file alone the very first step dies on schtasks'
+    # own "/ST is earlier than current time" warning, which this design provokes deliberately on EVERY
+    # step. Measured on de-DE 2026-09-11: verdict ERROR after 0.7 min, before a single action ran.
+    # The exit-code checks below are what actually decide success, and they are unaffected.
     $schtasksErr = Join-Path $work "$Label.schtasks.err"
-    & schtasks.exe /Create /TN $taskName /TR "`"$cmdFile`"" /SC ONCE /ST 00:00 /RU 'SYSTEM' /RL HIGHEST /F 2>$schtasksErr | Out-Null
+    & {
+        $ErrorActionPreference = 'Continue'
+        & schtasks.exe /Create /TN $taskName /TR "`"$cmdFile`"" /SC ONCE /ST 00:00 /RU 'SYSTEM' /RL HIGHEST /F 2>$schtasksErr | Out-Null
+    }
     if ($LASTEXITCODE -ne 0) { throw (Get-SchtasksFailure -Operation 'Create' -TaskName $taskName -Code $LASTEXITCODE -ErrFile $schtasksErr) }
-    & schtasks.exe /Run /TN $taskName 2>$schtasksErr | Out-Null
+    & {
+        $ErrorActionPreference = 'Continue'
+        & schtasks.exe /Run /TN $taskName 2>$schtasksErr | Out-Null
+    }
     if ($LASTEXITCODE -ne 0) { throw (Get-SchtasksFailure -Operation 'Run' -TaskName $taskName -Code $LASTEXITCODE -ErrFile $schtasksErr) }
 
+    # Everything below runs as SYSTEM through the scheduled task, which draws nothing on the guest
+    # desktop. A heartbeat is therefore the only way an operator watching the VM can tell a working
+    # install from a hung one - and telling those two apart by staring at an idle screen is exactly
+    # what cost hours on 2026-09-11.
+    try { $Host.UI.RawUI.WindowTitle = "PSADT Sandbox - $Label (running as SYSTEM)" } catch { }
+    Write-Host ("-> {0}: started as SYSTEM at {1}" -f $Label, (Get-Date -Format 'HH:mm:ss')) -ForegroundColor Cyan
+
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $startedAt = Get-Date
     $raw = $null
+    $tick = 0
     while ((Get-Date) -lt $deadline) {
         if (Test-Path -LiteralPath $codeFile) {
             $raw = Get-Content -LiteralPath $codeFile -Raw -ErrorAction SilentlyContinue
@@ -280,8 +300,19 @@ function Invoke-AsSystem {
         }
         Start-Sleep -Seconds 2
         $raw = $null
+        $tick++
+        if (($tick % 5) -eq 0) {
+            $secs = [int]((Get-Date) - $startedAt).TotalSeconds
+            Write-Host ("   {0}: still running - {1}s of max {2}s" -f $Label, $secs, $TimeoutSeconds) -ForegroundColor DarkGray
+        }
     }
-    & schtasks.exe /Delete /TN $taskName /F | Out-Null
+    # Same stderr trap as /Create and /Run: a task that is already gone makes schtasks write to stderr,
+    # which would end the whole run here - during CLEANUP, after the action itself already succeeded.
+    # Nothing about this call's outcome changes the verdict, so it neither throws nor is checked.
+    & {
+        $ErrorActionPreference = 'Continue'
+        & schtasks.exe /Delete /TN $taskName /F 2>&1 | Out-Null
+    }
 
     if (-not $raw) { return [pscustomobject]@{ ExitCode = $null; Output = ''; TimedOut = $true } }
 
@@ -309,7 +340,26 @@ function Invoke-Deployment {
     $exe = Join-Path $pkg 'Invoke-AppDeployToolkit.exe'
     $r = Invoke-AsSystem -Label $Label -CommandLine "`"$exe`" -DeploymentType $DeploymentType -DeployMode Silent" -TimeoutSeconds $actionTimeout
     $ok = (-not $r.TimedOut) -and ($successExitCodes -contains $r.ExitCode)
-    Add-Step $Label @{ exitCode = $r.ExitCode; timedOut = $r.TimedOut; success = $ok }
+    $step = @{ exitCode = $r.ExitCode; timedOut = $r.TimedOut; success = $ok }
+
+    # 60008 is the launcher's own "Initialization failed" code: the toolkit could not be imported or
+    # the session could not be opened, so nothing was deployed and no PSADT log was written. The .exe
+    # runs the .ps1 hidden and discards its stderr, so all that ever reaches this loop is the number -
+    # on 2026-09-11 it took two separate probe VMs to read the one line behind it. Because nothing ran,
+    # re-running the action ONCE through powershell.exe -File is side-effect-free, and it captures the
+    # error text the .exe threw away. 60001 is deliberately excluded: there the hook already executed
+    # and the PSADT log holds the cause.
+    if (-not $r.TimedOut -and $r.ExitCode -eq 60008) {
+        $ps1 = Join-Path $pkg 'Invoke-AppDeployToolkit.ps1'
+        $psExe = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+        $d = Invoke-AsSystem -Label "$Label.Diagnostic" -CommandLine "`"$psExe`" -NoProfile -ExecutionPolicy Bypass -File `"$ps1`" -DeploymentType $DeploymentType -DeployMode Silent" -TimeoutSeconds $actionTimeout
+        $diag = (('' + $d.Output) -replace '\s+', ' ').Trim()
+        if ($diag.Length -gt 1200) { $diag = $diag.Substring(0, 1200) + ' ...' }
+        $step.diagnostic = "$Label exited 60008 (initialization failed, nothing deployed). Re-run via powershell.exe -File said: $diag"
+        Write-Host "   !! $($step.diagnostic)" -ForegroundColor Yellow
+    }
+
+    Add-Step $Label $step
     Add-Assertion "$Label exit code" $ok "exit=$($r.ExitCode) timedOut=$($r.TimedOut)"
     return $r
 }
@@ -343,20 +393,145 @@ try {
     Start-Transcript -LiteralPath (Join-Path $results 'sandbox-transcript.txt') -Force | Out-Null
 
     # Every deployment action below goes through schtasks /RU SYSTEM /RL HIGHEST, which needs the full
-    # administrator token. <LogonCommand> supplied one implicitly; a Startup-folder item is launched by
-    # Explorer and inherits the token Explorer holds, so this stopped being true by construction when
-    # the trigger moved. Fail here in one second rather than let all seven actions fail identically
-    # further down, where the evidence points at the package instead.
+    # administrator token that <LogonCommand> supplies.
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $isElevated = ([Security.Principal.WindowsPrincipal]$identity).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     Add-Step 'Elevation' @{ elevated = $isElevated; identity = $identity.Name }
     if (-not $isElevated) {
-        throw "The sandbox runner is not elevated, so schtasks /RU SYSTEM /RL HIGHEST cannot work. The Startup-folder trigger handed it a filtered token."
+        throw "The sandbox runner is not elevated, so schtasks /RU SYSTEM /RL HIGHEST cannot work."
     }
+
+    # Elevation is NECESSARY BUT NOT SUFFICIENT, and believing otherwise is what made 2026-09-11
+    # expensive. A runner started from the guest's Startup folder passed the check above and still could
+    # not make the Task Scheduler run ANYTHING: schtasks /Create and /Run both returned exit 0 while the
+    # task never executed, and the cmdlet route was refused outright ("Cannot connect to CIM server.
+    # Access denied"). All seven deployment actions then died on identical timeouts that named no cause,
+    # and the evidence pointed at the package instead of at the harness.
+    #
+    # So prove the mechanism ONCE, in seconds, before spending twenty minutes per action on it. whoami
+    # is the smallest command that answers the only question that matters: did something actually run,
+    # and did it run as SYSTEM?
+    $canary = Invoke-AsSystem -Label 'SystemTaskCanary' -CommandLine 'whoami.exe' -TimeoutSeconds 90
+    $canaryWho = ('' + $canary.Output).Trim()
+    Add-Step 'SystemTaskCanary' @{ exitCode = $canary.ExitCode; timedOut = $canary.TimedOut; ranAs = $canaryWho }
+    if ($canary.TimedOut -or $canaryWho -notmatch '(?i)system') {
+        throw ("The sandbox cannot run a scheduled task as SYSTEM, so no deployment action could " +
+            "succeed here. A canary task that only runs whoami.exe " +
+            $(if ($canary.TimedOut) { 'never produced any output' } else { "reported '$canaryWho' instead of SYSTEM" }) +
+            ". This is a HARNESS/environment fault, not a fault in the package under test. The usual " +
+            "cause is the runner being started with a token that cannot drive the Task Scheduler - " +
+            "check that the .wsb still uses <LogonCommand> rather than a Startup-folder trigger.")
+    }
+
+    # --- Guest preparation: PowerShell module resources the sandbox image is missing -----------------
+    # PSADT imports Microsoft.PowerShell.Archive when it loads. That module localises its messages via
+    # Import-LocalizedData, and Windows PowerShell 5.1 does NOT fall back to another culture when the
+    # resource folder for the current UI culture is absent - the import throws, and every
+    # Invoke-AppDeployToolkit.ps1 dies in its Initialization block with 60008 before writing one log
+    # line. The sandbox base image on a de-DE host had exactly that hole on 2026-09-11: module present,
+    # de-DE\ArchiveResources.psd1 absent, while the host itself carried the file. A real device has its
+    # language pack, so this is a guest artefact - and the guest is patched to look like a real device.
+    # The host's culture folders for the modules PSADT imports were copied into the work folder at
+    # generation time; they are laid down here wherever the guest lacks them. Administrators hold Modify
+    # on these folders. Should a copy still fail, the PSADT module canary below reports the real error.
+    $resSrc = Join-Path $mapped 'ps-module-resources'
+    $modRoot = Join-Path $env:WinDir 'System32\WindowsPowerShell\v1.0\Modules'
+    $shimmed = New-Object System.Collections.Generic.List[string]
+    if (Test-Path -LiteralPath $resSrc) {
+        foreach ($mod in (Get-ChildItem -LiteralPath $resSrc -Directory)) {
+            $dstMod = Join-Path $modRoot $mod.Name
+            if (-not (Test-Path -LiteralPath $dstMod)) { continue }   # module not in the image - nothing to localise
+            foreach ($culture in (Get-ChildItem -LiteralPath $mod.FullName -Directory)) {
+                $dst = Join-Path $dstMod $culture.Name
+                if (Test-Path -LiteralPath $dst) { continue }
+                try {
+                    Copy-Item -LiteralPath $culture.FullName -Destination $dst -Recurse -Force -ErrorAction Stop
+                    $shimmed.Add("$($mod.Name)\$($culture.Name)")
+                } catch {
+                    Write-Host "   !! could not lay down $($mod.Name)\$($culture.Name): $($_.Exception.Message)"
+                }
+            }
+            # Culture-neutral fallback at the module root: Import-LocalizedData ends its search in the base
+            # directory, so this resolves even a guest UI culture the host does not carry.
+            $anyRes = Get-ChildItem -LiteralPath $mod.FullName -Recurse -File -Filter '*.psd1' | Select-Object -First 1
+            if ($anyRes -and -not (Test-Path -LiteralPath (Join-Path $dstMod $anyRes.Name))) {
+                try {
+                    Copy-Item -LiteralPath $anyRes.FullName -Destination $dstMod -Force -ErrorAction Stop
+                    $shimmed.Add("$($mod.Name)\$($anyRes.Name) (root fallback)")
+                } catch { }
+            }
+        }
+    }
+    # WMI/CIM must answer SYSTEM: Initialize-ADTModule queries root\cimv2:Win32_ComputerSystem for the
+    # hardware platform, and on 2026-09-11 that query came back 0x80070005 (Access denied) inside the
+    # guest - for SYSTEM and for the elevated runner alike - so Open-ADTSession threw and every action
+    # exited 60008 even after the module import had been repaired. The same guest image had passed on
+    # 2026-09-08; the host's cumulative updates of 2026-09-11 are the only change in between. The WMI
+    # repository carries the namespace security descriptors, so it is salvaged and, failing that, reset.
+    # Both are safe here: the VM is discarded when the run ends. The outcome is recorded either way and
+    # the session canary below turns a still-broken WMI into a named failure instead of 7 x 60008.
+    $wmiState = 'unknown'
+    try {
+        $svc = Get-Service -Name 'Winmgmt' -ErrorAction Stop
+        if ($svc.StartType -eq 'Disabled') { Set-Service -Name 'Winmgmt' -StartupType Automatic }
+        if ($svc.Status -ne 'Running') { Start-Service -Name 'Winmgmt' -ErrorAction Stop }
+        $null = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+        $wmiState = 'OK'
+    } catch {
+        $firstError = $_.Exception.Message
+        $wmiState = "denied ($firstError)"
+        foreach ($attempt in @('salvage', 'reset')) {
+            try {
+                Write-Host "   !! WMI refused Win32_ComputerSystem ($firstError) - trying winmgmt /${attempt}repository" -ForegroundColor Yellow
+                & { $ErrorActionPreference = 'Continue'; & winmgmt.exe "/${attempt}repository" 2>&1 | Out-Null }
+                Restart-Service -Name 'Winmgmt' -Force -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 5
+                $null = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+                $wmiState = "OK after winmgmt /${attempt}repository (was: $firstError)"
+                break
+            } catch {
+                $wmiState = "STILL denied after winmgmt /${attempt}repository ($($_.Exception.Message))"
+            }
+        }
+    }
+    Add-Step 'GuestPrepare' @{ uiCulture = (Get-UICulture).Name; wmi = $wmiState; resourcesShimmed = $(if ($shimmed.Count) { $shimmed -join ', ' } else { 'none needed' }) }
 
     # The mapped package folder is read-only and PSADT unblocks files under its own root, so work on a copy.
     Copy-Item -LiteralPath $pkgSrc -Destination $pkg -Recurse -Force
     Get-ChildItem -LiteralPath $pkg -Recurse -File | Unblock-File -ErrorAction SilentlyContinue
+
+    # --- PSADT module canary: can the package's toolkit be IMPORTED as SYSTEM in this guest? ---------
+    # Invoke-AppDeployToolkit.exe swallows the .ps1's stderr, so a failing toolkit import shows up only
+    # as a bare 60008 on every action and no log anywhere - exactly how 2026-09-11 presented, and it took
+    # a separate probe VM to read the one line that explained it. Import the toolkit once, as SYSTEM,
+    # with stderr captured, and stop with the REAL error text before the loop starts.
+    # Two stages, because they failed for two different reasons on the same day: the IMPORT (missing
+    # localized resource, fixed by GuestPrepare) and then OPEN-ADTSESSION (WMI refused to SYSTEM). The
+    # canary session is Silent, named so it cannot be mistaken for the package, and its log is removed
+    # again on success so it never lands in the package's evidence.
+    $modCanaryScript = Join-Path $work 'PsadtModuleCanary.ps1'
+    @(
+        "`$ErrorActionPreference = 'Stop'"
+        "try { Import-Module -Name '$pkg\PSAppDeployToolkit\PSAppDeployToolkit.psd1' -Force; Write-Output 'PSADT_MODULE_OK' }"
+        "catch { Write-Output ('PSADT_MODULE_FAILED: ' + `$_.Exception.Message); exit 1 }"
+        "try { `$null = Open-ADTSession -AppVendor 'PSADT' -AppName 'SandboxCanary' -AppVersion '1.0' -DeploymentType Install -DeployMode Silent -LogName 'PsadtSandboxCanary.log' -PassThru; Write-Output 'PSADT_SESSION_OK'; Close-ADTSession -ExitCode 0 -NoShellExit }"
+        "catch { Write-Output ('PSADT_SESSION_FAILED: ' + `$_.Exception.Message); exit 2 }"
+    ) | Set-Content -LiteralPath $modCanaryScript -Encoding ASCII
+    $psExeCanary = Join-Path $env:WinDir 'System32\WindowsPowerShell\v1.0\powershell.exe'
+    $mc = Invoke-AsSystem -Label 'PsadtModuleCanary' -CommandLine "`"$psExeCanary`" -NoProfile -ExecutionPolicy Bypass -File `"$modCanaryScript`"" -TimeoutSeconds 300
+    $mcOut = (('' + $mc.Output) -replace '\s+', ' ').Trim()
+    Add-Step 'PsadtModuleCanary' @{ exitCode = $mc.ExitCode; timedOut = $mc.TimedOut; result = $(if ($mcOut.Length -gt 600) { $mcOut.Substring(0, 600) } else { $mcOut }) }
+    if ($mc.TimedOut -or $mcOut -notmatch 'PSADT_SESSION_OK') {
+        $stage = if ($mcOut -notmatch 'PSADT_MODULE_OK') { 'imported' } else { 'opened as a session' }
+        throw ("The package's PSAppDeployToolkit cannot be $stage as SYSTEM inside this guest, so every " +
+            "deployment action would exit 60008 without writing a log. Real error: " +
+            $(if ($mc.TimedOut) { 'the canary never returned' } else { $mcOut }) +
+            ". A missing localized resource (e.g. ArchiveResources.psd1) means the sandbox image lacks a " +
+            "language-pack file a real device has; 'Win32_ComputerSystem ... 0x80070005' means WMI refuses SYSTEM " +
+            "in this guest - see the GuestPrepare step for what was attempted. Both are HARNESS/environment " +
+            "faults, not faults in the package under test.")
+    }
+    Remove-Item -LiteralPath (Join-Path $env:WinDir 'Logs\Software\PsadtSandboxCanary.log') -Force -ErrorAction SilentlyContinue
 
     Invoke-Deployment -Label 'Install'   -DeploymentType 'Install'   | Out-Null
     Test-Paths -Label 'present after install' -Paths $pathsPresentAfterInstall -ShouldExist $true
@@ -410,19 +585,42 @@ finally {
     # The cost of shutting down here is that the RDP-style client is left showing a connection-lost dialog -
     # which the host disposes of separately (Stop-SandboxInstance), so the user never sees it.
     Start-Sleep -Seconds 5   # let the mapped-folder writes above reach the host
-    & shutdown.exe /s /t 0
+
+    # Same stderr trap as the schtasks calls: $ErrorActionPreference is 'Stop', and in WinPS 5.1 a
+    # native command writing to stderr raises a terminating NativeCommandError. This is the LAST
+    # statement of the run and the one that tears the VM down - if it throws, the guest never shuts
+    # itself down, the vmmemWindowsSandbox worker keeps holding the mapped folder, and the next run
+    # is refused because Windows permits only one sandbox instance. Exactly that orphan blocked a
+    # re-run on 2026-09-11.
+    & {
+        $ErrorActionPreference = 'Continue'
+        & shutdown.exe /s /t 0 2>&1 | Out-Null
+    }
 }
 '@
 
-# Windows auto-executes only recognised extensions (.exe/.bat/.cmd/.lnk/.vbs) placed DIRECTLY in the
-# Startup folder, and a bare .ps1 loose in there additionally makes Explorer raise its own "how do you
-# want to open this file" prompt. So the runner lives in a 'runner' subfolder and only the one-line
-# trigger .cmd stays loose in Startup.
-$guestStartup = 'C:\Users\WDAGUtilityAccount\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup'
-$guestRunner  = Join-Path $guestStartup 'runner\Run-PsadtSandboxTest.ps1'
+# The work folder keeps its default mapping - the guest desktop - and the runner is started by the
+# .wsb LogonCommand.
+#
+# 0.28.0 replaced LogonCommand with a Startup-folder trigger to work around
+# microsoft/Windows-Sandbox#125 (LogonCommand never spawns a process on some Sandbox app versions).
+# Wherever LogonCommand DOES work, that workaround is worse than the bug it avoids, and it fails
+# silently: a Startup item is launched by Explorer, and although the resulting process still passes an
+# IsInRole(Administrator) check, its token cannot drive the Task Scheduler. Measured inside the guest
+# on 2026-09-11 (Sandbox app 0.8.107.0, guest 10.0.26100), with a standalone probe:
+#   * schtasks.exe /Create AND /Run both return exit 0 while the task NEVER executes - no marker file
+#     is ever written, so every deployment action reports a bare timeout that names no cause;
+#   * Register-ScheduledTask / Get-ScheduledTaskInfo fail with "Cannot connect to CIM server. Access
+#     denied", so the cmdlet route is not an alternative on that token either.
+# Under LogonCommand the very same schtasks calls work: five GREEN runs on this host, 2026-09-07 to
+# 2026-09-10, against the same Sandbox app version. LogonCommand therefore stays. #125 belongs where
+# it is already handled - the host times out waiting for DONE.txt and says the runner never started -
+# rather than being traded for a failure mode that looks like a broken package.
+$guestDesktop = 'C:\Users\WDAGUtilityAccount\Desktop'
+$guestRunner  = "$guestDesktop\$workLeaf\Run-PsadtSandboxTest.ps1"
 
 $runner = $runnerTemplate.
-    Replace('__MAPPEDROOT__', $guestStartup).
+    Replace('__MAPPEDROOT__', "$guestDesktop\$workLeaf").
     Replace('__PACKAGELEAF__', $packageLeaf).
     Replace('__DETECTIONSCRIPT__', ($DetectionScript -replace "'", "''")).
     Replace('__SUCCESSCODES__', ('@(' + ($SuccessExitCodes -join ', ') + ')')).
@@ -431,24 +629,45 @@ $runner = $runnerTemplate.
     Replace('__PATHSABSENTINSTALL__', (ConvertTo-PsArrayLiteral $PathsAbsentAfterInstall)).
     Replace('__PATHSABSENTUNINSTALL__', (ConvertTo-PsArrayLiteral $PathsAbsentAfterUninstall))
 
-$runnerPath = Join-Path $workFolder 'runner\Run-PsadtSandboxTest.ps1'
-New-Item -ItemType Directory -Path (Split-Path $runnerPath -Parent) -Force | Out-Null
+$runnerPath = Join-Path $workFolder 'Run-PsadtSandboxTest.ps1'
 [System.IO.File]::WriteAllText($runnerPath, $runner, [System.Text.UTF8Encoding]::new($true))
 
-# --- 4b. Startup-folder trigger (works around microsoft/Windows-Sandbox#125) ------------------------
-# On the affected Windows Sandbox app version, <LogonCommand> silently never executes at all - not
-# hidden, not delayed, the process is never spawned - while MappedFolders keeps working normally. The
-# documented workaround is to map a host folder straight onto the guest's Startup folder: that path is
-# driven by Windows' own logon mechanism rather than by the Sandbox app's LogonCommand code path, so
-# the bug does not reach it. The work folder itself is mapped there instead of adding a third mapping.
-$triggerLine = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$guestRunner`""
+# --- 4a. PowerShell module resources for the guest --------------------------------------------------
+# The sandbox base image can lack the localized resource folders (<culture>\*.psd1) of modules that
+# PSADT imports at load - measured 2026-09-11: Microsoft.PowerShell.Archive without de-DE\ on a de-DE
+# host that has it. Windows PowerShell 5.1 then throws on import instead of falling back, and every
+# launcher exits 60008 before its first log line. The host has whatever its language pack installed, so
+# its culture folders are shipped along and the runner lays them down inside the guest (GuestPrepare).
+# Only the modules PSADT's own import list names are considered; the psd1 filter keeps this to resource
+# files, never module code.
+$modRootHost = Join-Path $env:WINDIR 'System32\WindowsPowerShell\v1.0\Modules'
+$resDest = Join-Path $workFolder 'ps-module-resources'
+foreach ($modName in 'Microsoft.PowerShell.Archive', 'Dism', 'International', 'NetAdapter', 'ScheduledTasks') {
+    $modDir = Join-Path $modRootHost $modName
+    if (-not (Test-Path -LiteralPath $modDir)) { continue }
+    foreach ($cultureDir in (Get-ChildItem -LiteralPath $modDir -Directory | Where-Object { $_.Name -match '^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$' })) {
+        if (-not (Get-ChildItem -LiteralPath $cultureDir.FullName -File -Filter '*.psd1' -ErrorAction SilentlyContinue)) { continue }
+        $target = Join-Path (Join-Path $resDest $modName) $cultureDir.Name
+        New-Item -ItemType Directory -Path $target -Force | Out-Null
+        Copy-Item -Path (Join-Path $cultureDir.FullName '*.psd1') -Destination $target -Force
+    }
+}
+
+# --- 4b. LogonCommand line -------------------------------------------------------------------------
+# Deliberately NOT -WindowStyle Hidden: the console this opens inside the VM is the only thing an
+# operator watching the sandbox can see, and every deployment action below runs as SYSTEM through a
+# scheduled task, which by design draws nothing on the desktop. Without a visible window the VM looks
+# idle for minutes during a perfectly healthy install, which is indistinguishable from a hang.
+$logonCommand = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$guestRunner`""
 if ($GuestSettleDelaySeconds -gt 0) {
     # ping, not timeout: timeout needs a console it owns and aborts with "input redirection is not
     # supported" when it does not have one.
-    $triggerLine = "ping.exe -n $($GuestSettleDelaySeconds + 1) 127.0.0.1 > nul & " + $triggerLine
+    # The delay has to happen BEFORE the runner is launched, not inside it: the runner .ps1 itself lives
+    # in the mapped folder, so a mount that has not settled yet breaks the launch, not just the first read.
+    # Note the '&' - the value is XML-escaped on the way into the .wsb below, without which the whole
+    # configuration fails to parse and Windows Sandbox starts with no mapped folders at all.
+    $logonCommand = "cmd.exe /c `"ping.exe -n $($GuestSettleDelaySeconds + 1) 127.0.0.1 > nul & $logonCommand`""
 }
-$triggerScript = "@echo off`r`n$triggerLine`r`n"
-[System.IO.File]::WriteAllText((Join-Path $workFolder 'StartupTrigger.cmd'), $triggerScript, [System.Text.ASCIIEncoding]::new())
 
 # --- 5. Generate the .wsb configuration -------------------------------------------------------------
 $wsbPath = Join-Path $workRoot "$stem.wsb"
@@ -464,10 +683,12 @@ $wsb = @"
     </MappedFolder>
     <MappedFolder>
       <HostFolder>$workFolder</HostFolder>
-      <SandboxFolder>$guestStartup</SandboxFolder>
       <ReadOnly>false</ReadOnly>
     </MappedFolder>
   </MappedFolders>
+  <LogonCommand>
+    <Command>$([System.Security.SecurityElement]::Escape($logonCommand))</Command>
+  </LogonCommand>
 </Configuration>
 "@
 [System.IO.File]::WriteAllText($wsbPath, $wsb, [System.Text.UTF8Encoding]::new($false))

--- a/tests/Invoke-PsadtSandboxTest.Tests.ps1
+++ b/tests/Invoke-PsadtSandboxTest.Tests.ps1
@@ -272,11 +272,119 @@ Describe 'Invoke-PsadtSandboxTest' {
             $script:sysRunner | Should -Match "Get-SchtasksFailure -Operation 'Run'"
         }
 
-        It 'fails fast when the Startup trigger handed it a filtered token' {
-            # schtasks /RU SYSTEM /RL HIGHEST needs the full administrator token. LogonCommand supplied
-            # one implicitly; an Explorer-launched Startup item does not guarantee it.
+        It 'lowers ErrorActionPreference around the schtasks calls so their stderr cannot abort the run' {
+            # The ONCE trigger is deliberately in the past, so schtasks writes "/ST is earlier than
+            # current time" to STDERR on EVERY step. In WinPS 5.1 a native command's stderr raises a
+            # terminating NativeCommandError whenever $ErrorActionPreference is 'Stop', and a '2>file'
+            # redirect does NOT prevent that - it only chooses where the ErrorRecord is written. With
+            # the redirect alone the runner died on its very first step: measured on a de-DE host
+            # 2026-09-11, verdict ERROR after 0.7 minutes with no action executed.
+            # The exit-code checks above remain the real failure signal, so nothing is hidden.
+            $createBlock = [regex]::Match($script:sysRunner, "(?s)\&\s*\{[^}]*?schtasks\.exe\s+/Create.*?\}").Value
+            $createBlock | Should -Match "ErrorActionPreference\s*=\s*'Continue'"
+
+            $runBlock = [regex]::Match($script:sysRunner, "(?s)\&\s*\{[^}]*?schtasks\.exe\s+/Run.*?\}").Value
+            $runBlock | Should -Match "ErrorActionPreference\s*=\s*'Continue'"
+
+            $deleteBlock = [regex]::Match($script:sysRunner, "(?s)\&\s*\{[^}]*?schtasks\.exe\s+/Delete.*?\}").Value
+            $deleteBlock | Should -Match "ErrorActionPreference\s*=\s*'Continue'"
+        }
+
+        It 'guards the guest shutdown against the same stderr trap' {
+            # shutdown.exe is the LAST statement of the run and the one that tears the VM down. If its
+            # stderr raised a terminating error, the guest would never shut itself down, the
+            # vmmemWindowsSandbox worker would keep the mapped folder open, and the NEXT run would be
+            # refused - Windows permits exactly one sandbox instance. Observed as an orphaned VM on
+            # 2026-09-11, which blocked the re-run until it was cleaned up by hand.
+            $shutdownBlock = [regex]::Match($script:sysRunner, "(?s)\&\s*\{[^}]*?shutdown\.exe.*?\}").Value
+            $shutdownBlock | Should -Match "ErrorActionPreference\s*=\s*'Continue'"
+        }
+
+        It 'fails fast when the runner was handed a filtered token' {
+            # schtasks /RU SYSTEM /RL HIGHEST needs the full administrator token.
             $script:sysRunner | Should -Match 'WindowsBuiltInRole\]::Administrator'
             $script:sysRunner | Should -Match 'not elevated'
+        }
+
+        It 'proves a SYSTEM task actually RUNS before spending the full loop on it' {
+            # Elevation is necessary but not sufficient, and that gap cost a whole afternoon on
+            # 2026-09-11: a Startup-folder-launched runner passed the IsInRole check yet could not make
+            # the Task Scheduler run anything - schtasks returned exit 0 and the task never executed, so
+            # all seven actions timed out identically and the evidence pointed at the package.
+            # The canary answers the only question that matters, in seconds rather than hours.
+            $script:sysRunner | Should -Match "Label 'SystemTaskCanary'"
+            $script:sysRunner | Should -Match 'whoami\.exe'
+            $script:sysRunner | Should -Match "notmatch '\(\?i\)system'"
+            # and it must name the harness, not the package, as the culprit
+            $script:sysRunner | Should -Match 'HARNESS/environment fault'
+        }
+
+        It 'lays down missing PowerShell module resources in the guest before the first PSADT import' {
+            # Measured 2026-09-11: the sandbox image lacked de-DE\ArchiveResources.psd1 for
+            # Microsoft.PowerShell.Archive, which PSADT imports at load. WinPS 5.1 throws instead of
+            # falling back, so every launcher exited 60008 with no log - on every package, not just one.
+            $script:sysRunner | Should -Match 'ps-module-resources'
+            $script:sysRunner | Should -Match "Add-Step 'GuestPrepare'"
+            # the shim must run BEFORE the package is copied and any toolkit import happens
+            $script:sysRunner.IndexOf("Add-Step 'GuestPrepare'") | Should -BeLessThan $script:sysRunner.IndexOf('Copy-Item -LiteralPath $pkgSrc')
+        }
+
+        It 'repairs WMI for SYSTEM before the first PSADT session is opened' {
+            # Measured 2026-09-11: Initialize-ADTModule queries Win32_ComputerSystem and the guest
+            # answered 0x80070005 for SYSTEM, so Open-ADTSession threw - 60008 on every action, even
+            # after the module import itself had been fixed. The repository holds the namespace ACLs.
+            $script:sysRunner | Should -Match 'Win32_ComputerSystem'
+            $script:sysRunner | Should -Match 'Winmgmt'
+            $script:sysRunner | Should -Match 'salvage'
+            $script:sysRunner | Should -Match 'resetrepository|/\$\{attempt\}repository'
+            $script:sysRunner | Should -Match 'wmi = \$wmiState'
+        }
+
+        It 'imports the package toolkit AND opens a session once as SYSTEM, stopping with the real error text' {
+            # Invoke-AppDeployToolkit.exe swallows the .ps1 stderr, so an import or session failure is
+            # otherwise a bare 60008 on every action. Two stages, because they failed for two different
+            # reasons on the same day (missing localized resource, then WMI access denied).
+            $script:sysRunner | Should -Match "Label 'PsadtModuleCanary'"
+            $script:sysRunner | Should -Match 'PSADT_MODULE_OK'
+            $script:sysRunner | Should -Match 'Open-ADTSession'
+            $script:sysRunner | Should -Match 'PSADT_SESSION_OK'
+            $script:sysRunner | Should -Match 'Real error'
+            # the canary's own log must not end up in the package evidence
+            $script:sysRunner | Should -Match 'PsadtSandboxCanary\.log'
+            $script:sysRunner | Should -Match 'Remove-Item -LiteralPath \(Join-Path \$env:WinDir .Logs\\Software\\PsadtSandboxCanary\.log'
+            # and it runs after the copy (it imports from the copied package) but before the first action
+            $script:sysRunner.IndexOf("Label 'PsadtModuleCanary'") | Should -BeGreaterThan $script:sysRunner.IndexOf('Copy-Item -LiteralPath $pkgSrc')
+            $script:sysRunner.IndexOf("Label 'PsadtModuleCanary'") | Should -BeLessThan $script:sysRunner.IndexOf("Invoke-Deployment -Label 'Install'")
+        }
+
+        It 'ships the host''s module culture resources in the work folder' {
+            $hostArchive = Join-Path $env:WINDIR 'System32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive'
+            $hostCultures = @(Get-ChildItem -LiteralPath $hostArchive -Directory -ErrorAction SilentlyContinue | Where-Object { Get-ChildItem -LiteralPath $_.FullName -Filter '*.psd1' -File -ErrorAction SilentlyContinue })
+            if ($hostCultures.Count -eq 0) { Set-ItResult -Skipped -Because 'this host has no culture resource folder for Microsoft.PowerShell.Archive'; return }
+            $gen = & $script:script -PackagePath $script:pkg -GenerateOnly
+            foreach ($c in $hostCultures) {
+                (Join-Path $gen.SandboxWorkFolder "ps-module-resources\Microsoft.PowerShell.Archive\$($c.Name)\ArchiveResources.psd1") | Should -Exist
+            }
+        }
+
+        It 're-runs a 60008 action once through powershell.exe to capture the stderr the .exe discards' {
+            # 60008 = the launcher's Initialization block threw: nothing was deployed, no PSADT log exists,
+            # and Invoke-AppDeployToolkit.exe swallowed the .ps1's stderr. Re-running via -File is
+            # side-effect-free in that case and is the ONLY way the real error text reaches result.json.
+            $script:sysRunner | Should -Match '\$r\.ExitCode -eq 60008'
+            $script:sysRunner | Should -Match 'Invoke-AppDeployToolkit\.ps1'
+            $script:sysRunner | Should -Match '\.Diagnostic'
+            $script:sysRunner | Should -Match 'step\.diagnostic'
+            # 60001 must NOT trigger it - the hook already ran and a re-run would deploy twice
+            $script:sysRunner | Should -Not -Match '-eq 60001'
+        }
+
+        It 'shows a heartbeat while a SYSTEM action runs' {
+            # A SYSTEM scheduled task draws nothing on the guest desktop, so without this the VM looks
+            # frozen for minutes during a healthy install - indistinguishable from a hang to anyone
+            # watching the sandbox window.
+            $script:sysRunner | Should -Match 'still running'
+            $script:sysRunner | Should -Match 'WindowTitle'
         }
 
         It 'retries a captured output that reads back empty' {
@@ -301,43 +409,43 @@ Describe 'Invoke-PsadtSandboxTest' {
             ($folders | Where-Object { $_.HostFolder -like '*_PsadtSandboxTest' }).ReadOnly | Should -Be 'false'
         }
 
-        It 'carries no LogonCommand - it silently never executes on the affected Sandbox app version' {
-            # microsoft/Windows-Sandbox#125: the process is never spawned at all, while MappedFolders
-            # keeps working. A LogonCommand here would look correct and do nothing.
+        It 'starts the runner through LogonCommand' {
+            # 0.28.0 swapped LogonCommand for a Startup-folder trigger to dodge
+            # microsoft/Windows-Sandbox#125 (LogonCommand never spawns on some Sandbox app versions).
+            # Measured on 2026-09-11, that trade is a bad one wherever LogonCommand works: a
+            # Startup-launched runner inherits Explorer's token, and with it schtasks /Create and /Run
+            # both return exit 0 while the task NEVER executes (and the ScheduledTasks cmdlets are
+            # refused with "Cannot connect to CIM server. Access denied"). Every action then times out
+            # blaming the package. #125 is caught by the host's DONE.txt timeout instead.
             $xml = [xml](Get-Content -LiteralPath $script:gen.WsbPath -Raw)
-            $xml.Configuration.LogonCommand | Should -BeNullOrEmpty
+            $xml.Configuration.LogonCommand.Command | Should -Match 'Run-PsadtSandboxTest\.ps1'
         }
 
-        It 'maps the work folder onto the guest Startup folder rather than the Desktop' {
+        It 'does not hide the guest console window' {
+            # The console is the only visible sign of life in the VM: every deployment action runs as
+            # SYSTEM via a scheduled task and draws nothing on the desktop.
+            $xml = [xml](Get-Content -LiteralPath $script:gen.WsbPath -Raw)
+            $xml.Configuration.LogonCommand.Command | Should -Not -Match '(?i)-WindowStyle\s+Hidden'
+        }
+
+        It 'leaves the work folder at its default desktop mapping' {
+            # No SandboxFolder override: the guest sees it as C:\Users\WDAGUtilityAccount\Desktop\<leaf>,
+            # which is where the runner template and the LogonCommand both expect it.
             $xml = [xml](Get-Content -LiteralPath $script:gen.WsbPath -Raw)
             $folders = @($xml.Configuration.MappedFolders.MappedFolder)
             $work = $folders | Where-Object { $_.HostFolder -like '*_PsadtSandboxTest' }
-            $work.SandboxFolder | Should -Be 'C:\Users\WDAGUtilityAccount\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup'
+            $work.SandboxFolder | Should -BeNullOrEmpty
+            $script:gen.RunnerPath | Should -Match '_PsadtSandboxTest.Run-PsadtSandboxTest\.ps1$'
         }
 
-        It 'starts the runner from a trigger .cmd placed loose in the work folder' {
-            # Only .exe/.bat/.cmd/.lnk/.vbs are auto-executed from Startup, so the entry point has to
-            # be the .cmd; the .ps1 it launches lives one level down.
-            $triggerPath = Join-Path $script:gen.SandboxWorkFolder 'StartupTrigger.cmd'
-            $triggerPath | Should -Exist
-            (Get-Content -LiteralPath $triggerPath -Raw) | Should -Match 'Run-PsadtSandboxTest\.ps1'
-        }
-
-        It 'keeps the runner .ps1 out of the Startup root, where Explorer prompts for it' {
-            # A bare .ps1 sitting directly in Startup makes Explorer raise its own "how do you want to
-            # open this file" dialog, even though the .cmd already launches it correctly.
-            $script:gen.RunnerPath | Should -Match 'runner.Run-PsadtSandboxTest\.ps1$'
-            (Join-Path $script:gen.SandboxWorkFolder 'Run-PsadtSandboxTest.ps1') | Should -Not -Exist
-        }
-
-        It 'waits inside the trigger only when a settle delay was asked for' {
-            $plain = Get-Content -LiteralPath (Join-Path $script:gen.SandboxWorkFolder 'StartupTrigger.cmd') -Raw
-            $plain | Should -Not -Match 'ping\.exe'
+        It 'waits before starting the runner only when a settle delay was asked for' {
+            $xml = [xml](Get-Content -LiteralPath $script:gen.WsbPath -Raw)
+            $xml.Configuration.LogonCommand.Command | Should -Not -Match 'ping\.exe'
 
             $delayed = & $script:script -PackagePath $script:pkg -GenerateOnly -GuestSettleDelaySeconds 20
-            $text = Get-Content -LiteralPath (Join-Path $delayed.SandboxWorkFolder 'StartupTrigger.cmd') -Raw
+            $dx = [xml](Get-Content -LiteralPath $delayed.WsbPath -Raw)
             # ping, not timeout: timeout aborts without a console it owns.
-            $text | Should -Match 'ping\.exe -n 21 127\.0\.0\.1'
+            $dx.Configuration.LogonCommand.Command | Should -Match 'ping\.exe -n 21 127\.0\.0\.1'
         }
     }
 


### PR DESCRIPTION
Found while packaging Google Chrome for Intune - the first sandbox run on this host after 0.28.0. Five faults were stacked on top of each other and every one hid the next: the run died before its first action, then every action timed out with no cause, then every action exited 60008 with no log, then 60008 again for a different reason. Each was measured inside the guest with a standalone probe before it was fixed.

### Fixed
- **The 0.28.0 Startup-folder trigger could not run a single task as SYSTEM.** The runner passed `IsInRole(Administrator)`, yet `schtasks /Create` and `/Run` returned 0 while the task never executed, and `Register-ScheduledTask` was refused ("Cannot connect to CIM server. Access denied"). Every action timed out blaming the package. `<LogonCommand>` is back (the five GREEN runs before 0.28.0 used it); microsoft/Windows-Sandbox#125 is left to the host's `DONE.txt` timeout.
- **`schtasks`' stderr notice ended the run before the first action.** In WinPS 5.1 a `2>file` redirect does not stop the terminating `NativeCommandError` under `$ErrorActionPreference='Stop'` (measured; the 0.28.0 comment claimed otherwise). The preference is lowered around the three `schtasks` calls and the final `shutdown.exe`; exit codes are still checked.
- **The sandbox image lacked `de-DE\ArchiveResources.psd1`**, which PSADT needs just to import - 60008 before the first log line, for any package. The host's culture resources for the modules PSADT imports are shipped in the work folder and laid down in the guest (`GuestPrepare`).
- **WMI refused SYSTEM inside the guest** (`Win32_ComputerSystem` -> `0x80070005`), so `Open-ADTSession` threw - 60008 again. The same image passed on 2026-09-08; the host's cumulative updates of 2026-09-11 are the only change. `GuestPrepare` verifies WMI and salvages, then resets, the repository.

### Added
- **Three canaries before the loop** (SYSTEM task via `whoami`, toolkit import, a real Silent toolkit session as SYSTEM). Each fails in seconds with the real error text and names a HARNESS/environment fault.
- **A 60008 action is re-run once via `powershell.exe -File`** with stderr captured onto the step (`diagnostic`). The `.exe` discards it, and 60008 means nothing was deployed, so the re-run is side-effect-free.
- **Heartbeat + window title in the guest console**, so a healthy install no longer looks like a hang.
- Appendix G lessons for the day. **Suite 493 -> 501**, all green locally.

### Changed
- `-GuestSettleDelaySeconds` moved into the LogonCommand and is XML-escaped (an unescaped `&` makes the `.wsb` unparseable - caught by the suite).

### Verification
- Full suite: 501 passed / 0 failed.
- Google Chrome 153.0.8010.37 sandbox loop with this harness: **GREEN**, 14 steps, 9.9 min, no failed assertion (Install/Uninstall/Reinstall/Repair/FinalUninstall all exit 0, detection correct after each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
